### PR TITLE
Use single full-year period for 2025 tax year

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,7 @@ import ResultsPage from './components/Results';
 import Footer from './components/Footer';
 
 const periods: Period[] = [
-    new Period(new Date(2025, 0, 1), new Date(2025, 5, 24), 'Period 1'),
-    new Period(new Date(2025, 5, 25), new Date(2025, 11, 31), 'Period 2'),
+    new Period(new Date(2025, 0, 1), new Date(2025, 11, 31), '2025'),
 ];
 
 const App = () => {

--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -13,16 +13,18 @@ const formatPeriodDates = (period: Period): string => {
     return `${start} \u2013 ${end}`;
 };
 
-const PeriodBlock = ({ row }: { row: GainsType }) => {
+const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean }) => {
     const period = row['Period'] as Period;
     const gainLoss = row['Gain (loss)'] as number;
     const gainClass = gainLoss >= 0 ? 'gain-positive' : 'gain-negative';
 
     return (
         <>
-            <div className="cra-period-title">
-                {period.name} &middot; {formatPeriodDates(period)}
-            </div>
+            {showPeriod && (
+                <div className="cra-period-title">
+                    {period.name} &middot; {formatPeriodDates(period)}
+                </div>
+            )}
             <div className="cra-row">
                 <span className="cra-row-label">Proceeds of disposition</span>
                 <span className="cra-row-value">{formatCurrency(row['Proceeds'] as number)}</span>
@@ -44,11 +46,13 @@ const PeriodBlock = ({ row }: { row: GainsType }) => {
 };
 
 const TaxSummary = ({ totals }: TaxSummaryProps) => {
+    const showPeriod = totals.length > 1;
+
     return (
         <div className="cra-card mb-4">
             <div className="cra-header">Schedule 3 &mdash; Capital Gains (Losses)</div>
             {totals.map((row, i) => (
-                <PeriodBlock key={i} row={row} />
+                <PeriodBlock key={i} row={row} showPeriod={showPeriod} />
             ))}
             <div className="d-flex justify-content-end p-2">
                 <CSVLink className="btn btn-sm btn-outline-primary" data={totals}>


### PR DESCRIPTION
2025 no longer has two capital gains inclusion rate periods. Define a single Jan 1 - Dec 31 period and hide the period title in the tax summary when only one period is configured.

Multi-period logic is preserved for future use if needed.