### PR TITLE
Clean up syntax for readability

### DIFF
--- a/src/utils/GainsCalculator.ts
+++ b/src/utils/GainsCalculator.ts
@@ -2,17 +2,10 @@ import { parseCurrency } from './format';
 import { ExchangeRateFetcher } from './fetchRates';
 
 export class Period {
-    start: Date;
-    end: Date;
-    name: string;
-    constructor(start: Date, end: Date, name: string) {
-        this.start = start;
-        this.end = end;
-        this.name = name;
-    }
+    constructor(public start: Date, public end: Date, public name: string) { }
 
     public toString(): string {
-        return this.name + ': ' + this.start.toLocaleDateString() + ' - ' + this.end.toLocaleDateString();
+        return `${this.name}: ${this.start.toLocaleDateString()} - ${this.end.toLocaleDateString()}`;
     }
 }
 
@@ -58,13 +51,7 @@ export interface ResultsType {
 }
 
 export class GainsCalculator {
-    private sales: EtradeData[];
-    private periods: Period[];
-
-    constructor(sales: EtradeData[], periods: Period[]) {
-        this.sales = sales;
-        this.periods = periods;
-    }
+    constructor(private sales: EtradeData[], private periods: Period[]) { }
 
     private getDates(dateColumn: keyof EtradeData): string[] {
         return this.sales.map(row => row[dateColumn]);
@@ -112,9 +99,7 @@ export class GainsCalculator {
     }
 
     private getPeriodForDate(date: Date): Period {
-        const period = this.periods.find((p: Period) => {
-            return date >= p.start && date <= p.end;
-        });
+        const period = this.periods.find(p => date >= p.start && date <= p.end);
         if (!period) {
             throw new Error(`No period found for date: ${date}`);
         }
@@ -147,7 +132,7 @@ export class GainsCalculator {
             gains.push({
                 'Period': this.getPeriodForDate(dateSold),
                 'Date Sold': row['Date Sold'],
-                'Description': row['Symbol'] + ' ' + row['Plan Type'],
+                'Description': `${row['Symbol']} ${row['Plan Type']}`,
                 'Proceeds': this.roundToTwoDecimals(proceeds),
                 'Cost base': this.roundToTwoDecimals(costBase),
                 'Expenses': 0,
@@ -155,9 +140,7 @@ export class GainsCalculator {
             } as GainsType);
         });
 
-        const total = this.periods.map((period: Period) => {
-            return this.getTotalForPeriod(period, gains);
-        });
+        const total = this.periods.map(period => this.getTotalForPeriod(period, gains));
 
         const exchangeRates: ExchangeRate[] = Object.entries(rates)
             .map(([date, rate]) => ({ date, rate }))

--- a/src/utils/fetchRates.ts
+++ b/src/utils/fetchRates.ts
@@ -6,11 +6,7 @@ interface Observation {
 }
 
 export class ExchangeRateFetcher {
-    private apiUrl: string;
-
-    constructor() {
-        this.apiUrl = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
-    }
+    private apiUrl = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
 
     /**
      * Fetches conversion rates for a list of dates.
@@ -28,7 +24,7 @@ export class ExchangeRateFetcher {
 
             const rates: Record<string, number> = {};
             dates.forEach(date => {
-                const dateStr = date.toISOString().split('T')[0]
+                const dateStr = date.toISOString().split('T')[0];
                 const observation = this.findObservationByDateWithLookback(observations, date);
                 if (observation && observation['FXUSDCAD']) {
                     rates[dateStr] = parseFloat(observation['FXUSDCAD'].v);
@@ -40,7 +36,7 @@ export class ExchangeRateFetcher {
             return rates;
         } catch (error) {
             if (error instanceof Error) {
-                throw new Error('Failed to fetch exchange rates: ' + error.message);
+                throw new Error(`Failed to fetch exchange rates: ${error.message}`);
             } else {
                 throw new Error('Failed to fetch exchange rates: An unknown error occurred.');
             }

--- a/src/utils/xlsParser.ts
+++ b/src/utils/xlsParser.ts
@@ -19,13 +19,9 @@ export const parseXls = async (file: File): Promise<ParseResult> => {
     const headers = rows[0].map(cell => String(cell ?? ''));
     const dataRows = rows.slice(1);
 
-    const allRows: EtradeData[] = dataRows.map(row => {
-        const obj: Record<string, string> = {};
-        headers.forEach((header, i) => {
-            obj[header] = row[i] != null ? String(row[i]) : '';
-        });
-        return obj as EtradeData;
-    });
+    const allRows = dataRows.map(row =>
+        Object.fromEntries(headers.map((header, i) => [header, row[i] != null ? String(row[i]) : '']))
+    ) as EtradeData[];
 
     const summary = allRows.find(r => r['Record Type'] === 'Summary') ?? null;
     const sales = allRows.filter(r => r['Record Type'] === 'Sell');


### PR DESCRIPTION
- Use template literals instead of string concatenation
- Use implicit arrow returns where possible
- Remove redundant type annotations (let TS infer)
- Replace verbose forEach with Object.fromEntries in xlsParser
- Fix missing semicolon in fetchRates