### PR TITLE
refactor(utils): replace Java-style classes with idiomatic TS modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "bootstrap": "^5.3.8",
+        "date-fns": "^4.1.0",
         "react": "^19.2.5",
         "react-bootstrap": "^2.10.10",
         "react-csv": "^2.2.2",
@@ -1572,6 +1573,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.3.8",
+    "date-fns": "^4.1.0",
     "react": "^19.2.5",
     "react-bootstrap": "^2.10.10",
     "react-csv": "^2.2.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 import { parseXls, type ParseResult } from './utils/xlsParser';
-import { GainsCalculator, Period, type EtradeData, type ResultsType } from './utils/GainsCalculator';
+import { calculateTax, type EtradeData, type Period, type ResultsType } from './utils/GainsCalculator';
 import LandingPage from './components/LandingPage';
 import ResultsPage from './components/Results';
 import Footer from './components/Footer';
 
 const periods: Period[] = [
-    new Period(new Date(2025, 0, 1), new Date(2025, 11, 31), '2025'),
+    { start: new Date(2025, 0, 1), end: new Date(2025, 11, 31), name: '2025' },
 ];
 
 const App = () => {
@@ -16,7 +16,7 @@ const App = () => {
     const handleFileSelect = async (file: File) => {
         const parsed: ParseResult = await parseXls(file);
         setSummary(parsed.summary);
-        const calculated = await new GainsCalculator(parsed.sales, periods).calculateTax();
+        const calculated = await calculateTax(parsed.sales, periods);
         setResults(calculated);
     };
 

--- a/src/components/DataVerification.tsx
+++ b/src/components/DataVerification.tsx
@@ -1,7 +1,7 @@
 import { Accordion, Table } from 'react-bootstrap';
 import ExchangeRatesTable from './ExchangeRatesTable';
 import TransactionsTable from './TransactionsTable';
-import type { EtradeData, ExchangeRate, GainsType, VerificationData } from '../utils/GainsCalculator';
+import { ETRADE_FIELD, type EtradeData, type ExchangeRate, type GainsType, type VerificationData } from '../utils/GainsCalculator';
 import { formatCurrency, parseCurrency } from '../utils/format';
 
 interface DataVerificationProps {
@@ -46,7 +46,7 @@ const DataVerification = ({ verification, summary, exchangeRates, gains }: DataV
     const crossChecks: CrossCheckRow[] = [];
 
     if (summary) {
-        const summaryProceeds = parseCurrency(summary['Total Proceeds']);
+        const summaryProceeds = parseCurrency(summary[ETRADE_FIELD.TotalProceeds]);
         if (summaryProceeds !== null) {
             crossChecks.push({
                 label: 'Total Proceeds',
@@ -55,8 +55,8 @@ const DataVerification = ({ verification, summary, exchangeRates, gains }: DataV
             });
         }
 
-        const summaryGainLoss = parseCurrency(summary['Adjusted Gain/Loss'])
-            ?? parseCurrency(summary['Gain/Loss']);
+        const summaryGainLoss = parseCurrency(summary[ETRADE_FIELD.AdjustedGainLoss])
+            ?? parseCurrency(summary[ETRADE_FIELD.GainLoss]);
         if (summaryGainLoss !== null) {
             crossChecks.push({
                 label: 'Adjusted Gain/Loss',

--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -14,8 +14,8 @@ const formatPeriodDates = (period: Period): string => {
 };
 
 const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean }) => {
-    const period = row['Period'] as Period;
-    const gainLoss = row['Gain (loss)'] as number;
+    const period = row['Period'];
+    const gainLoss = row['Gain (loss)'];
     const gainClass = gainLoss >= 0 ? 'gain-positive' : 'gain-negative';
 
     return (
@@ -27,15 +27,15 @@ const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean 
             )}
             <div className="cra-row">
                 <span className="cra-row-label">Proceeds of disposition</span>
-                <span className="cra-row-value">{formatCurrency(row['Proceeds'] as number)}</span>
+                <span className="cra-row-value">{formatCurrency(row['Proceeds'])}</span>
             </div>
             <div className="cra-row">
                 <span className="cra-row-label">Adjusted cost base</span>
-                <span className="cra-row-value">{formatCurrency(row['Cost base'] as number)}</span>
+                <span className="cra-row-value">{formatCurrency(row['Cost base'])}</span>
             </div>
             <div className="cra-row">
                 <span className="cra-row-label">Outlays and expenses</span>
-                <span className="cra-row-value">{formatCurrency(row['Expenses'] as number)}</span>
+                <span className="cra-row-value">{formatCurrency(row['Expenses'])}</span>
             </div>
             <div className="cra-row cra-row-highlight">
                 <span className="cra-row-label">Gain (Loss)</span>

--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -1,6 +1,6 @@
 import { CSVLink } from 'react-csv';
-import type { GainsType, Period } from '../utils/GainsCalculator';
-import { formatCurrency } from '../utils/format';
+import { GAIN_FIELD, type GainsType, type Period } from '../utils/GainsCalculator';
+import { formatCurrency, gainClass } from '../utils/format';
 
 interface TaxSummaryProps {
     totals: GainsType[];
@@ -14,9 +14,8 @@ const formatPeriodDates = (period: Period): string => {
 };
 
 const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean }) => {
-    const period = row['Period'];
-    const gainLoss = row['Gain (loss)'];
-    const gainClass = gainLoss >= 0 ? 'gain-positive' : 'gain-negative';
+    const period = row[GAIN_FIELD.Period];
+    const gainLoss = row[GAIN_FIELD.GainLoss];
 
     return (
         <>
@@ -27,19 +26,19 @@ const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean 
             )}
             <div className="cra-row">
                 <span className="cra-row-label">Proceeds of disposition</span>
-                <span className="cra-row-value">{formatCurrency(row['Proceeds'])}</span>
+                <span className="cra-row-value">{formatCurrency(row[GAIN_FIELD.Proceeds])}</span>
             </div>
             <div className="cra-row">
                 <span className="cra-row-label">Adjusted cost base</span>
-                <span className="cra-row-value">{formatCurrency(row['Cost base'])}</span>
+                <span className="cra-row-value">{formatCurrency(row[GAIN_FIELD.CostBase])}</span>
             </div>
             <div className="cra-row">
                 <span className="cra-row-label">Outlays and expenses</span>
-                <span className="cra-row-value">{formatCurrency(row['Expenses'])}</span>
+                <span className="cra-row-value">{formatCurrency(row[GAIN_FIELD.Expenses])}</span>
             </div>
             <div className="cra-row cra-row-highlight">
                 <span className="cra-row-label">Gain (Loss)</span>
-                <span className={`cra-row-value ${gainClass}`}>{formatCurrency(gainLoss)}</span>
+                <span className={`cra-row-value ${gainClass(gainLoss)}`}>{formatCurrency(gainLoss)}</span>
             </div>
         </>
     );

--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { CSVLink } from 'react-csv';
 import { GAIN_FIELD, type GainsType, type Period } from '../utils/GainsCalculator';
 import { formatCurrency, gainClass } from '../utils/format';
@@ -6,12 +7,8 @@ interface TaxSummaryProps {
     totals: GainsType[];
 }
 
-const formatPeriodDates = (period: Period): string => {
-    const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
-    const start = period.start.toLocaleDateString('en-CA', opts);
-    const end = period.end.toLocaleDateString('en-CA', { ...opts, year: 'numeric' });
-    return `${start} \u2013 ${end}`;
-};
+const formatPeriodDates = (period: Period): string =>
+    `${format(period.start, 'MMM d')} \u2013 ${format(period.end, 'MMM d, yyyy')}`;
 
 const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean }) => {
     const period = row[GAIN_FIELD.Period];

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -12,7 +12,7 @@ const TransactionsTable = ({ data }: TransactionsTableProps) => {
         return <div>No data available</div>;
     }
 
-    const showPeriod = new Set(data.map(r => r['Period'].toString())).size > 1;
+    const showPeriod = new Set(data.map(r => r['Period'].name)).size > 1;
 
     return (
         <div>
@@ -36,17 +36,17 @@ const TransactionsTable = ({ data }: TransactionsTableProps) => {
                 </thead>
                 <tbody>
                     {data.map((row, index) => {
-                        const gainLoss = row['Gain (loss)'] as number;
+                        const gainLoss = row['Gain (loss)'];
                         const gainClass = gainLoss >= 0 ? 'gain-positive' : 'gain-negative';
                         return (
                             <tr key={index}>
                                 <td>{index + 1}</td>
-                                {showPeriod && <td>{String(row['Period'])}</td>}
-                                <td>{formatDate(row['Date Sold'] as string)}</td>
+                                {showPeriod && <td>{row['Period'].name}</td>}
+                                <td>{formatDate(row['Date Sold'])}</td>
                                 <td>{row['Description']}</td>
-                                <td className="text-end">{formatCurrency(row['Proceeds'] as number)}</td>
-                                <td className="text-end">{formatCurrency(row['Cost base'] as number)}</td>
-                                <td className="text-end">{formatCurrency(row['Expenses'] as number)}</td>
+                                <td className="text-end">{formatCurrency(row['Proceeds'])}</td>
+                                <td className="text-end">{formatCurrency(row['Cost base'])}</td>
+                                <td className="text-end">{formatCurrency(row['Expenses'])}</td>
                                 <td className={`text-end ${gainClass}`}>
                                     {formatCurrency(gainLoss)}
                                 </td>

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -1,7 +1,7 @@
 import { Table } from 'react-bootstrap';
 import { CSVLink } from 'react-csv';
-import type { GainsType } from '../utils/GainsCalculator';
-import { formatCurrency, formatDate } from '../utils/format';
+import { GAIN_FIELD, type GainsType } from '../utils/GainsCalculator';
+import { formatCurrency, formatDate, gainClass } from '../utils/format';
 
 interface TransactionsTableProps {
     data: GainsType[];
@@ -12,7 +12,7 @@ const TransactionsTable = ({ data }: TransactionsTableProps) => {
         return <div>No data available</div>;
     }
 
-    const showPeriod = new Set(data.map(r => r['Period'].name)).size > 1;
+    const showPeriod = new Set(data.map(r => r[GAIN_FIELD.Period].name)).size > 1;
 
     return (
         <div>
@@ -36,18 +36,17 @@ const TransactionsTable = ({ data }: TransactionsTableProps) => {
                 </thead>
                 <tbody>
                     {data.map((row, index) => {
-                        const gainLoss = row['Gain (loss)'];
-                        const gainClass = gainLoss >= 0 ? 'gain-positive' : 'gain-negative';
+                        const gainLoss = row[GAIN_FIELD.GainLoss];
                         return (
                             <tr key={index}>
                                 <td>{index + 1}</td>
-                                {showPeriod && <td>{row['Period'].name}</td>}
-                                <td>{formatDate(row['Date Sold'])}</td>
-                                <td>{row['Description']}</td>
-                                <td className="text-end">{formatCurrency(row['Proceeds'])}</td>
-                                <td className="text-end">{formatCurrency(row['Cost base'])}</td>
-                                <td className="text-end">{formatCurrency(row['Expenses'])}</td>
-                                <td className={`text-end ${gainClass}`}>
+                                {showPeriod && <td>{row[GAIN_FIELD.Period].name}</td>}
+                                <td>{formatDate(row[GAIN_FIELD.DateSold])}</td>
+                                <td>{row[GAIN_FIELD.Description]}</td>
+                                <td className="text-end">{formatCurrency(row[GAIN_FIELD.Proceeds])}</td>
+                                <td className="text-end">{formatCurrency(row[GAIN_FIELD.CostBase])}</td>
+                                <td className="text-end">{formatCurrency(row[GAIN_FIELD.Expenses])}</td>
+                                <td className={`text-end ${gainClass(gainLoss)}`}>
                                     {formatCurrency(gainLoss)}
                                 </td>
                             </tr>

--- a/src/utils/GainsCalculator.ts
+++ b/src/utils/GainsCalculator.ts
@@ -1,4 +1,5 @@
-import { parseCurrency } from './format';
+import { format, isWithinInterval } from 'date-fns';
+import { parseCurrency, toIsoDate } from './format';
 import { fetchRates } from './fetchRates';
 
 export type Period = {
@@ -8,7 +9,7 @@ export type Period = {
 };
 
 export const formatPeriod = (p: Period): string =>
-    `${p.name}: ${p.start.toLocaleDateString()} - ${p.end.toLocaleDateString()}`;
+    `${p.name}: ${format(p.start, 'P')} - ${format(p.end, 'P')}`;
 
 export const GAIN_FIELD = {
     Period: 'Period',
@@ -83,12 +84,11 @@ type NumericGainKey =
 
 const strToNum = (str: string): number => parseCurrency(str) ?? 0;
 const round2 = (n: number): number => Math.round(n * 100) / 100;
-const toIsoDate = (d: Date): string => d.toISOString().split('T')[0];
 
 const findPeriod = (periods: Period[], date: Date): Period => {
-    const period = periods.find(p => date >= p.start && date <= p.end);
+    const period = periods.find(p => isWithinInterval(date, { start: p.start, end: p.end }));
     if (!period) {
-        throw new Error(`No period found for date: ${date.toISOString()}`);
+        throw new Error(`No period found for date: ${toIsoDate(date)}`);
     }
     return period;
 };

--- a/src/utils/GainsCalculator.ts
+++ b/src/utils/GainsCalculator.ts
@@ -10,27 +10,51 @@ export type Period = {
 export const formatPeriod = (p: Period): string =>
     `${p.name}: ${p.start.toLocaleDateString()} - ${p.end.toLocaleDateString()}`;
 
-export interface GainsType {
-    'Period': Period;
-    'Date Sold': string;
-    'Description': string;
-    'Proceeds': number;
-    'Cost base': number;
-    'Expenses': number;
-    'Gain (loss)': number;
-}
+export const GAIN_FIELD = {
+    Period: 'Period',
+    DateSold: 'Date Sold',
+    Description: 'Description',
+    Proceeds: 'Proceeds',
+    CostBase: 'Cost base',
+    Expenses: 'Expenses',
+    GainLoss: 'Gain (loss)',
+} as const;
 
-export interface EtradeData {
-    'Record Type': string;
-    'Date Sold': string;
-    'Date Acquired': string;
-    'Total Proceeds': string;
-    'Adjusted Cost Basis': string;
-    'Symbol': string;
-    'Plan Type': string;
-    'Adjusted Gain/Loss'?: string;
-    'Gain/Loss'?: string;
-}
+export const ETRADE_FIELD = {
+    RecordType: 'Record Type',
+    DateSold: 'Date Sold',
+    DateAcquired: 'Date Acquired',
+    TotalProceeds: 'Total Proceeds',
+    AdjustedCostBasis: 'Adjusted Cost Basis',
+    Symbol: 'Symbol',
+    PlanType: 'Plan Type',
+    AdjustedGainLoss: 'Adjusted Gain/Loss',
+    GainLoss: 'Gain/Loss',
+} as const;
+
+export type RecordType = 'Sell' | 'Summary';
+
+export type GainsType = {
+    [GAIN_FIELD.Period]: Period;
+    [GAIN_FIELD.DateSold]: string;
+    [GAIN_FIELD.Description]: string;
+    [GAIN_FIELD.Proceeds]: number;
+    [GAIN_FIELD.CostBase]: number;
+    [GAIN_FIELD.Expenses]: number;
+    [GAIN_FIELD.GainLoss]: number;
+};
+
+export type EtradeData = {
+    [ETRADE_FIELD.RecordType]: RecordType;
+    [ETRADE_FIELD.DateSold]: string;
+    [ETRADE_FIELD.DateAcquired]: string;
+    [ETRADE_FIELD.TotalProceeds]: string;
+    [ETRADE_FIELD.AdjustedCostBasis]: string;
+    [ETRADE_FIELD.Symbol]: string;
+    [ETRADE_FIELD.PlanType]: string;
+    [ETRADE_FIELD.AdjustedGainLoss]?: string;
+    [ETRADE_FIELD.GainLoss]?: string;
+};
 
 export interface VerificationData {
     sellCount: number;
@@ -51,7 +75,11 @@ export interface ResultsType {
     exchangeRates: ExchangeRate[];
 }
 
-type NumericGainKey = 'Proceeds' | 'Cost base' | 'Expenses' | 'Gain (loss)';
+type NumericGainKey =
+    | typeof GAIN_FIELD.Proceeds
+    | typeof GAIN_FIELD.CostBase
+    | typeof GAIN_FIELD.Expenses
+    | typeof GAIN_FIELD.GainLoss;
 
 const strToNum = (str: string): number => parseCurrency(str) ?? 0;
 const round2 = (n: number): number => Math.round(n * 100) / 100;
@@ -70,45 +98,45 @@ const buildGain = (
     periods: Period[],
     rates: Record<string, number>,
 ): GainsType => {
-    const dateSold = new Date(row['Date Sold']);
-    const dateAcquired = new Date(row['Date Acquired']);
-    const proceedsUsd = strToNum(row['Total Proceeds']);
-    const costBaseUsd = strToNum(row['Adjusted Cost Basis']);
+    const dateSold = new Date(row[ETRADE_FIELD.DateSold]);
+    const dateAcquired = new Date(row[ETRADE_FIELD.DateAcquired]);
+    const proceedsUsd = strToNum(row[ETRADE_FIELD.TotalProceeds]);
+    const costBaseUsd = strToNum(row[ETRADE_FIELD.AdjustedCostBasis]);
     const proceeds = proceedsUsd * rates[toIsoDate(dateSold)];
     const costBase = costBaseUsd * rates[toIsoDate(dateAcquired)];
 
     return {
-        'Period': findPeriod(periods, dateSold),
-        'Date Sold': row['Date Sold'],
-        'Description': `${row['Symbol']} ${row['Plan Type']}`,
-        'Proceeds': round2(proceeds),
-        'Cost base': round2(costBase),
-        'Expenses': 0,
-        'Gain (loss)': round2(proceeds - costBase),
+        [GAIN_FIELD.Period]: findPeriod(periods, dateSold),
+        [GAIN_FIELD.DateSold]: row[ETRADE_FIELD.DateSold],
+        [GAIN_FIELD.Description]: `${row[ETRADE_FIELD.Symbol]} ${row[ETRADE_FIELD.PlanType]}`,
+        [GAIN_FIELD.Proceeds]: round2(proceeds),
+        [GAIN_FIELD.CostBase]: round2(costBase),
+        [GAIN_FIELD.Expenses]: 0,
+        [GAIN_FIELD.GainLoss]: round2(proceeds - costBase),
     };
 };
 
 const totalForPeriod = (period: Period, gains: GainsType[]): GainsType => {
-    const inPeriod = gains.filter(g => g.Period === period);
+    const inPeriod = gains.filter(g => g[GAIN_FIELD.Period] === period);
     const sum = (key: NumericGainKey): number =>
         round2(inPeriod.reduce((acc, row) => acc + row[key], 0));
 
     return {
-        'Period': period,
-        'Date Sold': '',
-        'Description': '',
-        'Proceeds': sum('Proceeds'),
-        'Cost base': sum('Cost base'),
-        'Expenses': sum('Expenses'),
-        'Gain (loss)': sum('Gain (loss)'),
+        [GAIN_FIELD.Period]: period,
+        [GAIN_FIELD.DateSold]: '',
+        [GAIN_FIELD.Description]: '',
+        [GAIN_FIELD.Proceeds]: sum(GAIN_FIELD.Proceeds),
+        [GAIN_FIELD.CostBase]: sum(GAIN_FIELD.CostBase),
+        [GAIN_FIELD.Expenses]: sum(GAIN_FIELD.Expenses),
+        [GAIN_FIELD.GainLoss]: sum(GAIN_FIELD.GainLoss),
     };
 };
 
 const usdTotals = (sales: EtradeData[]): { usdProceeds: number; usdGainLoss: number } =>
     sales.reduce(
         (acc, row) => {
-            const proceeds = strToNum(row['Total Proceeds']);
-            const costBase = strToNum(row['Adjusted Cost Basis']);
+            const proceeds = strToNum(row[ETRADE_FIELD.TotalProceeds]);
+            const costBase = strToNum(row[ETRADE_FIELD.AdjustedCostBasis]);
             return {
                 usdProceeds: acc.usdProceeds + proceeds,
                 usdGainLoss: acc.usdGainLoss + (proceeds - costBase),
@@ -121,7 +149,7 @@ export const calculateTax = async (
     sales: EtradeData[],
     periods: Period[],
 ): Promise<ResultsType> => {
-    const allDateStrs = sales.flatMap(row => [row['Date Acquired'], row['Date Sold']]);
+    const allDateStrs = sales.flatMap(row => [row[ETRADE_FIELD.DateAcquired], row[ETRADE_FIELD.DateSold]]);
     const uniqueDateStrs = Array.from(new Set(allDateStrs));
     const rates = await fetchRates(uniqueDateStrs.map(d => new Date(d)));
 

--- a/src/utils/GainsCalculator.ts
+++ b/src/utils/GainsCalculator.ts
@@ -1,16 +1,16 @@
 import { parseCurrency } from './format';
-import { ExchangeRateFetcher } from './fetchRates';
+import { fetchRates } from './fetchRates';
 
-export class Period {
-    constructor(public start: Date, public end: Date, public name: string) { }
+export type Period = {
+    start: Date;
+    end: Date;
+    name: string;
+};
 
-    public toString(): string {
-        return `${this.name}: ${this.start.toLocaleDateString()} - ${this.end.toLocaleDateString()}`;
-    }
-}
+export const formatPeriod = (p: Period): string =>
+    `${p.name}: ${p.start.toLocaleDateString()} - ${p.end.toLocaleDateString()}`;
 
 export interface GainsType {
-    [key: string]: string | number | Period;
     'Period': Period;
     'Date Sold': string;
     'Description': string;
@@ -21,7 +21,6 @@ export interface GainsType {
 }
 
 export interface EtradeData {
-    [key: string]: string;
     'Record Type': string;
     'Date Sold': string;
     'Date Acquired': string;
@@ -29,6 +28,8 @@ export interface EtradeData {
     'Adjusted Cost Basis': string;
     'Symbol': string;
     'Plan Type': string;
+    'Adjusted Gain/Loss'?: string;
+    'Gain/Loss'?: string;
 }
 
 export interface VerificationData {
@@ -50,112 +51,97 @@ export interface ResultsType {
     exchangeRates: ExchangeRate[];
 }
 
-export class GainsCalculator {
-    constructor(private sales: EtradeData[], private periods: Period[]) { }
+type NumericGainKey = 'Proceeds' | 'Cost base' | 'Expenses' | 'Gain (loss)';
 
-    private getDates(dateColumn: keyof EtradeData): string[] {
-        return this.sales.map(row => row[dateColumn]);
+const strToNum = (str: string): number => parseCurrency(str) ?? 0;
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+const toIsoDate = (d: Date): string => d.toISOString().split('T')[0];
+
+const findPeriod = (periods: Period[], date: Date): Period => {
+    const period = periods.find(p => date >= p.start && date <= p.end);
+    if (!period) {
+        throw new Error(`No period found for date: ${date.toISOString()}`);
     }
+    return period;
+};
 
-    private getFxRates(): Promise<Record<string, number>> {
-        const allDatesStr = this.getDates('Date Acquired').concat(this.getDates('Date Sold'));
-        const allDates = Array.from(new Set(allDatesStr)).map(date => new Date(date));
-        return new ExchangeRateFetcher().fetchRates(allDates);
-    }
+const buildGain = (
+    row: EtradeData,
+    periods: Period[],
+    rates: Record<string, number>,
+): GainsType => {
+    const dateSold = new Date(row['Date Sold']);
+    const dateAcquired = new Date(row['Date Acquired']);
+    const proceedsUsd = strToNum(row['Total Proceeds']);
+    const costBaseUsd = strToNum(row['Adjusted Cost Basis']);
+    const proceeds = proceedsUsd * rates[toIsoDate(dateSold)];
+    const costBase = costBaseUsd * rates[toIsoDate(dateAcquired)];
 
-    private strToNum(str: string): number {
-        return parseCurrency(str) ?? 0;
-    }
+    return {
+        'Period': findPeriod(periods, dateSold),
+        'Date Sold': row['Date Sold'],
+        'Description': `${row['Symbol']} ${row['Plan Type']}`,
+        'Proceeds': round2(proceeds),
+        'Cost base': round2(costBase),
+        'Expenses': 0,
+        'Gain (loss)': round2(proceeds - costBase),
+    };
+};
 
-    private roundToTwoDecimals(num: number): number {
-        return Math.round(num * 100) / 100;
-    }
+const totalForPeriod = (period: Period, gains: GainsType[]): GainsType => {
+    const inPeriod = gains.filter(g => g.Period === period);
+    const sum = (key: NumericGainKey): number =>
+        round2(inPeriod.reduce((acc, row) => acc + row[key], 0));
 
-    private getTotalForPeriod(period: Period, gains: GainsType[]): GainsType {
-        const total = gains.reduce((acc, row) => {
-            if (row.Period !== period) {
-                return acc;
-            }
-            acc['Proceeds'] += row['Proceeds'];
-            acc['Cost base'] += row['Cost base'];
-            acc['Expenses'] += row['Expenses'];
-            acc['Gain (loss)'] += row['Gain (loss)'];
-            return acc;
-        }, {
-            'Period': period,
-            'Date Sold': '',
-            'Description': '',
-            'Proceeds': 0,
-            'Cost base': 0,
-            'Expenses': 0,
-            'Gain (loss)': 0,
-        } as GainsType);
+    return {
+        'Period': period,
+        'Date Sold': '',
+        'Description': '',
+        'Proceeds': sum('Proceeds'),
+        'Cost base': sum('Cost base'),
+        'Expenses': sum('Expenses'),
+        'Gain (loss)': sum('Gain (loss)'),
+    };
+};
 
-        total['Proceeds'] = this.roundToTwoDecimals(total['Proceeds']);
-        total['Cost base'] = this.roundToTwoDecimals(total['Cost base']);
-        total['Expenses'] = this.roundToTwoDecimals(total['Expenses']);
-        total['Gain (loss)'] = this.roundToTwoDecimals(total['Gain (loss)']);
-        return total;
-    }
+const usdTotals = (sales: EtradeData[]): { usdProceeds: number; usdGainLoss: number } =>
+    sales.reduce(
+        (acc, row) => {
+            const proceeds = strToNum(row['Total Proceeds']);
+            const costBase = strToNum(row['Adjusted Cost Basis']);
+            return {
+                usdProceeds: acc.usdProceeds + proceeds,
+                usdGainLoss: acc.usdGainLoss + (proceeds - costBase),
+            };
+        },
+        { usdProceeds: 0, usdGainLoss: 0 },
+    );
 
-    private getPeriodForDate(date: Date): Period {
-        const period = this.periods.find(p => date >= p.start && date <= p.end);
-        if (!period) {
-            throw new Error(`No period found for date: ${date}`);
-        }
-        return period;
-    }
+export const calculateTax = async (
+    sales: EtradeData[],
+    periods: Period[],
+): Promise<ResultsType> => {
+    const allDateStrs = sales.flatMap(row => [row['Date Acquired'], row['Date Sold']]);
+    const uniqueDateStrs = Array.from(new Set(allDateStrs));
+    const rates = await fetchRates(uniqueDateStrs.map(d => new Date(d)));
 
-    public async calculateTax(): Promise<ResultsType> {
-        const rates = await this.getFxRates();
+    const gains = sales.map(row => buildGain(row, periods, rates));
+    const total = periods.map(p => totalForPeriod(p, gains));
+    const { usdProceeds, usdGainLoss } = usdTotals(sales);
 
-        const allDatesStr = this.getDates('Date Acquired').concat(this.getDates('Date Sold'));
-        const uniqueDates = new Set(allDatesStr).size;
+    const exchangeRates: ExchangeRate[] = Object.entries(rates)
+        .map(([date, rate]) => ({ date, rate }))
+        .sort((a, b) => a.date.localeCompare(b.date));
 
-        let usdProceeds = 0;
-        let usdGainLoss = 0;
-
-        const gains: GainsType[] = [];
-        this.sales.forEach(row => {
-            const dateSold = new Date(row['Date Sold']);
-            const dateAcquired = new Date(row['Date Acquired']);
-            const rateSold = rates[dateSold.toISOString().split('T')[0]];
-            const rateAcquired = rates[dateAcquired.toISOString().split('T')[0]];
-            const proceedsUsd = this.strToNum(row['Total Proceeds']);
-            const costBaseUsd = this.strToNum(row['Adjusted Cost Basis']);
-            const proceeds = proceedsUsd * rateSold;
-            const costBase = costBaseUsd * rateAcquired;
-
-            usdProceeds += proceedsUsd;
-            usdGainLoss += proceedsUsd - costBaseUsd;
-
-            gains.push({
-                'Period': this.getPeriodForDate(dateSold),
-                'Date Sold': row['Date Sold'],
-                'Description': `${row['Symbol']} ${row['Plan Type']}`,
-                'Proceeds': this.roundToTwoDecimals(proceeds),
-                'Cost base': this.roundToTwoDecimals(costBase),
-                'Expenses': 0,
-                'Gain (loss)': this.roundToTwoDecimals(proceeds - costBase),
-            } as GainsType);
-        });
-
-        const total = this.periods.map(period => this.getTotalForPeriod(period, gains));
-
-        const exchangeRates: ExchangeRate[] = Object.entries(rates)
-            .map(([date, rate]) => ({ date, rate }))
-            .sort((a, b) => a.date.localeCompare(b.date));
-
-        return {
-            gains,
-            total,
-            verification: {
-                sellCount: this.sales.length,
-                uniqueDates,
-                usdProceeds: this.roundToTwoDecimals(usdProceeds),
-                usdGainLoss: this.roundToTwoDecimals(usdGainLoss),
-            },
-            exchangeRates,
-        };
-    }
-}
+    return {
+        gains,
+        total,
+        verification: {
+            sellCount: sales.length,
+            uniqueDates: uniqueDateStrs.length,
+            usdProceeds: round2(usdProceeds),
+            usdGainLoss: round2(usdGainLoss),
+        },
+        exchangeRates,
+    };
+};

--- a/src/utils/fetchRates.ts
+++ b/src/utils/fetchRates.ts
@@ -1,3 +1,6 @@
+import { subDays } from 'date-fns';
+import { toIsoDate } from './format';
+
 interface Observation {
     d: string;
     FXUSDCAD?: { v: string };
@@ -6,8 +9,6 @@ interface Observation {
 const API_URL = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
 const MAX_LOOKBACK_DAYS = 2;
 
-const toIsoDate = (d: Date): string => d.toISOString().split('T')[0];
-
 const findObservation = (observations: Observation[], date: Date): Observation | undefined => {
     const target = toIsoDate(date);
     return observations.find(obs => obs.d === target);
@@ -15,9 +16,7 @@ const findObservation = (observations: Observation[], date: Date): Observation |
 
 const findWithLookback = (observations: Observation[], date: Date): Observation | undefined => {
     for (let days = 0; days <= MAX_LOOKBACK_DAYS; days++) {
-        const lookback = new Date(date);
-        lookback.setDate(date.getDate() - days);
-        const observation = findObservation(observations, lookback);
+        const observation = findObservation(observations, subDays(date, days));
         if (observation?.FXUSDCAD) return observation;
     }
     return undefined;

--- a/src/utils/fetchRates.ts
+++ b/src/utils/fetchRates.ts
@@ -1,64 +1,45 @@
 interface Observation {
-    d: string; // Date in 'YYYY-MM-DD' format
-    FXUSDCAD?: {
-        v: string; // Conversion rate
-    };
+    d: string;
+    FXUSDCAD?: { v: string };
 }
 
-export class ExchangeRateFetcher {
-    private apiUrl = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
+const API_URL = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
+const MAX_LOOKBACK_DAYS = 2;
 
-    /**
-     * Fetches conversion rates for a list of dates.
-     * @param dates - An array of dates in the format 'YYYY-MM-DD'.
-     * @returns A promise that resolves to an object where keys are dates and values are conversion rates.
-     */
-    public async fetchRates(dates: Date[]): Promise<Record<string, number>> {
-        try {
-            const response = await fetch(this.apiUrl);
-            if (!response.ok) {
-                throw new Error(`HTTP error: ${response.status}`);
-            }
-            const data = await response.json() as { observations: { d: string; FXUSDCAD?: { v: string } }[] };
-            const observations = data.observations;
+const toIsoDate = (d: Date): string => d.toISOString().split('T')[0];
 
-            const rates: Record<string, number> = {};
-            dates.forEach(date => {
-                const dateStr = date.toISOString().split('T')[0];
-                const observation = this.findObservationByDateWithLookback(observations, date);
-                if (observation && observation['FXUSDCAD']) {
-                    rates[dateStr] = parseFloat(observation['FXUSDCAD'].v);
-                } else {
-                    rates[dateStr] = NaN; // If no rate is found for the date, set it to NaN
-                }
-            });
+const findObservation = (observations: Observation[], date: Date): Observation | undefined => {
+    const target = toIsoDate(date);
+    return observations.find(obs => obs.d === target);
+};
 
-            return rates;
-        } catch (error) {
-            if (error instanceof Error) {
-                throw new Error(`Failed to fetch exchange rates: ${error.message}`);
-            } else {
-                throw new Error('Failed to fetch exchange rates: An unknown error occurred.');
-            }
+const findWithLookback = (observations: Observation[], date: Date): Observation | undefined => {
+    for (let days = 0; days <= MAX_LOOKBACK_DAYS; days++) {
+        const lookback = new Date(date);
+        lookback.setDate(date.getDate() - days);
+        const observation = findObservation(observations, lookback);
+        if (observation?.FXUSDCAD) return observation;
+    }
+    return undefined;
+};
+
+export const fetchRates = async (dates: Date[]): Promise<Record<string, number>> => {
+    try {
+        const response = await fetch(API_URL);
+        if (!response.ok) {
+            throw new Error(`HTTP error: ${response.status}`);
         }
-    }
+        const data = await response.json() as { observations: Observation[] };
 
-    private findObservationByDate(observations: Observation[], date: Date): Observation | undefined {
-        return observations.find((obs) => obs.d === date.toISOString().split('T')[0]);
+        return Object.fromEntries(
+            dates.map(date => {
+                const observation = findWithLookback(data.observations, date);
+                const rate = observation?.FXUSDCAD ? parseFloat(observation.FXUSDCAD.v) : NaN;
+                return [toIsoDate(date), rate];
+            }),
+        );
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : 'An unknown error occurred.';
+        throw new Error(`Failed to fetch exchange rates: ${msg}`);
     }
-
-    private findObservationByDateWithLookback(observations: Observation[], date: Date): Observation | undefined {
-        const maxlookbackDays = 2; // Number of days to look back
-        let lookbackDays = 0;
-        while (lookbackDays <= maxlookbackDays) {
-            const lookbackDate = new Date(date);
-            lookbackDate.setDate(date.getDate() - lookbackDays);
-            const observation = this.findObservationByDate(observations, lookbackDate);
-            if (observation && observation['FXUSDCAD']) {
-                return observation;
-            }
-            lookbackDays++;
-        }
-        return undefined;
-    }
-}
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,7 @@
+import { format, isValid } from 'date-fns';
+
+const ISO_DATE = 'yyyy-MM-dd';
+
 export const formatCurrency = (value: number): string => {
     const abs = Math.abs(value);
     const formatted = abs.toLocaleString('en-CA', {
@@ -13,10 +17,11 @@ export const parseCurrency = (str: string | undefined): number | null => {
     return isNaN(value) ? null : value;
 };
 
+export const toIsoDate = (date: Date): string => format(date, ISO_DATE);
+
 export const formatDate = (value: string): string => {
     const date = new Date(value);
-    if (isNaN(date.getTime())) return value;
-    return date.toLocaleDateString('en-CA'); // YYYY-MM-DD
+    return isValid(date) ? format(date, ISO_DATE) : value;
 };
 
 export type GainClass = 'gain-positive' | 'gain-negative';

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -18,3 +18,8 @@ export const formatDate = (value: string): string => {
     if (isNaN(date.getTime())) return value;
     return date.toLocaleDateString('en-CA'); // YYYY-MM-DD
 };
+
+export type GainClass = 'gain-positive' | 'gain-negative';
+
+export const gainClass = (value: number): GainClass =>
+    value >= 0 ? 'gain-positive' : 'gain-negative';

--- a/src/utils/xlsParser.ts
+++ b/src/utils/xlsParser.ts
@@ -1,5 +1,5 @@
 import readXlsxFile, { type Row } from 'read-excel-file/browser';
-import type { EtradeData } from './GainsCalculator';
+import { ETRADE_FIELD, type EtradeData } from './GainsCalculator';
 
 export interface ParseResult {
     sales: EtradeData[];
@@ -25,8 +25,8 @@ export const parseXls = async (file: File): Promise<ParseResult> => {
         ) as unknown as EtradeData,
     );
 
-    const summary = allRows.find(r => r['Record Type'] === 'Summary') ?? null;
-    const sales = allRows.filter(r => r['Record Type'] === 'Sell');
+    const summary = allRows.find(r => r[ETRADE_FIELD.RecordType] === 'Summary') ?? null;
+    const sales = allRows.filter(r => r[ETRADE_FIELD.RecordType] === 'Sell');
 
     return {
         sales,

--- a/src/utils/xlsParser.ts
+++ b/src/utils/xlsParser.ts
@@ -20,8 +20,10 @@ export const parseXls = async (file: File): Promise<ParseResult> => {
     const dataRows = rows.slice(1);
 
     const allRows = dataRows.map(row =>
-        Object.fromEntries(headers.map((header, i) => [header, row[i] != null ? String(row[i]) : '']))
-    ) as EtradeData[];
+        Object.fromEntries(
+            headers.map((header, i) => [header, row[i] != null ? String(row[i]) : '']),
+        ) as unknown as EtradeData,
+    );
 
     const summary = allRows.find(r => r['Record Type'] === 'Summary') ?? null;
     const sales = allRows.filter(r => r['Record Type'] === 'Sell');


### PR DESCRIPTION
- Convert Period class to type alias + formatPeriod helper
- Replace ExchangeRateFetcher class with fetchRates function
- Replace GainsCalculator class with calculateTax function + module-level helpers
- Make period aggregation immutable (filter + reduce instead of mutating accumulator)
- Replace forEach+mutation with Object.fromEntries in xlsParser and fetchRates
- Drop index signatures from GainsType/EtradeData, removing ~10 now-unneeded type casts in consumers
- Add optional Adjusted Gain/Loss and Gain/Loss fields to EtradeData for summary rows