### PR TITLE
Add exchange rate lookback info, Date Acquired column, and BoC links

### DIFF
--- a/src/components/ExchangeRatesTable.tsx
+++ b/src/components/ExchangeRatesTable.tsx
@@ -1,7 +1,11 @@
 import { Table } from 'react-bootstrap';
+import { BoxArrowUpRight } from 'react-bootstrap-icons';
 import type { ExchangeRate } from '../utils/GainsCalculator';
 import { formatDate } from '../utils/format';
 import { formatMoney } from '../utils/money';
+
+const bocUrl = (date: string) =>
+    `https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates-lookup/?lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&series%5B%5D=FXUSDCAD&lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&rangeType=range&rangeValue=&dFrom=${date}&dTo=&submit_button=Submit`;
 
 interface ExchangeRatesTableProps {
     rates: ExchangeRate[];
@@ -17,18 +21,32 @@ const ExchangeRatesTable = ({ rates }: ExchangeRatesTableProps) => {
             <thead>
                 <tr>
                     <th>Date</th>
-                    <th className="text-end">USD/CAD Rate</th>
+                    <th className="text-end">USD &rarr; CAD Rate</th>
                 </tr>
             </thead>
             <tbody>
-                {rates.map((r) => (
-                    <tr key={r.date}>
-                        <td>{formatDate(r.date)}</td>
-                        <td className="text-end" style={{ fontFamily: "'Courier New', monospace" }}>
-                            {formatMoney(r.rate, { decimals: 4 })}
-                        </td>
-                    </tr>
-                ))}
+                {rates.map((r) => {
+                    const lookback = r.date !== r.rateDate;
+                    return (
+                        <tr key={r.date}>
+                            <td>
+                                {formatDate(r.date)}
+                                {lookback && <span className="text-muted ms-1 small">(rate from {formatDate(r.rateDate)})</span>}
+                            </td>
+                            <td className="text-end" style={{ fontFamily: "'Courier New', monospace" }}>
+                                <a
+                                    href={bocUrl(r.rateDate)}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-decoration-none"
+                                >
+                                    {formatMoney(r.rate, { decimals: 4 })}
+                                    &nbsp;<BoxArrowUpRight size={10} className="text-muted" />
+                                </a>
+                            </td>
+                        </tr>
+                    );
+                })}
             </tbody>
         </Table>
     );

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -10,6 +10,7 @@ interface TransactionsTableProps {
 
 const toCsvRow = (row: GainsType) => ({
     [GAIN_FIELD.Period]: row[GAIN_FIELD.Period].name,
+    [GAIN_FIELD.DateAcquired]: row[GAIN_FIELD.DateAcquired],
     [GAIN_FIELD.DateSold]: row[GAIN_FIELD.DateSold],
     [GAIN_FIELD.Description]: row[GAIN_FIELD.Description],
     [GAIN_FIELD.Proceeds]: formatMoney(row[GAIN_FIELD.Proceeds]),
@@ -37,6 +38,7 @@ const TransactionsTable = ({ data }: TransactionsTableProps) => {
                     <tr>
                         <th>#</th>
                         {showPeriod && <th>Period</th>}
+                        <th>Date Acquired</th>
                         <th>Date Sold</th>
                         <th>Description</th>
                         <th className="text-end">Proceeds</th>
@@ -50,8 +52,9 @@ const TransactionsTable = ({ data }: TransactionsTableProps) => {
                         const gainLoss = row[GAIN_FIELD.GainLoss];
                         return (
                             <tr key={index}>
-                                <td>{index + 1}</td>
+                                <td className="text-muted">{index + 1}</td>
                                 {showPeriod && <td>{row[GAIN_FIELD.Period].name}</td>}
+                                <td>{formatDate(row[GAIN_FIELD.DateAcquired])}</td>
                                 <td>{formatDate(row[GAIN_FIELD.DateSold])}</td>
                                 <td>{row[GAIN_FIELD.Description]}</td>
                                 <td className="text-end">{formatCurrency(row[GAIN_FIELD.Proceeds])}</td>

--- a/src/utils/GainsCalculator.spec.ts
+++ b/src/utils/GainsCalculator.spec.ts
@@ -43,8 +43,9 @@ const sale = (opts: {
     [ETRADE_FIELD.PlanType]: opts.plan ?? 'RS',
 });
 
-const gain = (period: Period, dateSold: string, proceeds: bigint, costBase: bigint): GainsType => ({
+const gain = (period: Period, dateAcquired: string, dateSold: string, proceeds: bigint, costBase: bigint): GainsType => ({
     [GAIN_FIELD.Period]: period,
+    [GAIN_FIELD.DateAcquired]: dateAcquired,
     [GAIN_FIELD.DateSold]: dateSold,
     [GAIN_FIELD.Description]: 'ACME RS',
     [GAIN_FIELD.Proceeds]: proceeds,
@@ -55,6 +56,7 @@ const gain = (period: Period, dateSold: string, proceeds: bigint, costBase: bigi
 
 const totalRow = (period: Period, proceeds: bigint, costBase: bigint, gainLoss: bigint): GainsType => ({
     [GAIN_FIELD.Period]: period,
+    [GAIN_FIELD.DateAcquired]: '',
     [GAIN_FIELD.DateSold]: '',
     [GAIN_FIELD.Description]: '',
     [GAIN_FIELD.Proceeds]: proceeds,
@@ -92,10 +94,10 @@ describe('calculateTax (integration)', () => {
 
         const expected: ResultsType = {
             gains: [
-                gain(q1, '02/10/2025', 1_430_000_000n, 1_080_000_000n),
-                gain(q1, '03/20/2025',   700_000_000n,   852_000_000n),
-                gain(q1, '03/25/2025', 2_780_000_000n, 2_115_000_000n),
-                gain(q2, '05/15/2025', 2_070_000_000n, 1_680_000_000n),
+                gain(q1, '12/01/2024', '02/10/2025', 1_430_000_000n, 1_080_000_000n),
+                gain(q1, '01/15/2025', '03/20/2025',   700_000_000n,   852_000_000n),
+                gain(q1, '02/01/2025', '03/25/2025', 2_780_000_000n, 2_115_000_000n),
+                gain(q2, '01/10/2025', '05/15/2025', 2_070_000_000n, 1_680_000_000n),
             ],
             total: [
                 totalRow(q1, 4_910_000_000n, 4_047_000_000n, 863_000_000n),
@@ -108,14 +110,14 @@ describe('calculateTax (integration)', () => {
                 usdGainLoss: m(  900_000_000n),
             },
             exchangeRates: [
-                { date: '2024-12-01', rate: m(1_350_000n) },
-                { date: '2025-01-10', rate: m(1_400_000n) },
-                { date: '2025-01-15', rate: m(1_420_000n) },
-                { date: '2025-02-01', rate: m(1_410_000n) },
-                { date: '2025-02-10', rate: m(1_430_000n) },
-                { date: '2025-03-20', rate: m(1_400_000n) },
-                { date: '2025-03-25', rate: m(1_390_000n) },
-                { date: '2025-05-15', rate: m(1_380_000n) },
+                { date: '2024-12-01', rateDate: '2024-12-01', rate: m(1_350_000n) },
+                { date: '2025-01-10', rateDate: '2025-01-10', rate: m(1_400_000n) },
+                { date: '2025-01-15', rateDate: '2025-01-15', rate: m(1_420_000n) },
+                { date: '2025-02-01', rateDate: '2025-02-01', rate: m(1_410_000n) },
+                { date: '2025-02-10', rateDate: '2025-02-10', rate: m(1_430_000n) },
+                { date: '2025-03-20', rateDate: '2025-03-20', rate: m(1_400_000n) },
+                { date: '2025-03-25', rateDate: '2025-03-25', rate: m(1_390_000n) },
+                { date: '2025-05-15', rateDate: '2025-05-15', rate: m(1_380_000n) },
             ],
         };
 
@@ -135,7 +137,7 @@ describe('calculateTax (integration)', () => {
         const result = await calculateTax(sales, [period]);
 
         expect(result.gains).toEqual([
-            gain(period, '03/16/2025', 140_000_000n, 140_000_000n),
+            gain(period, '03/15/2025', '03/16/2025', 140_000_000n, 140_000_000n),
         ]);
     });
 

--- a/src/utils/GainsCalculator.ts
+++ b/src/utils/GainsCalculator.ts
@@ -1,6 +1,6 @@
 import { isWithinInterval } from 'date-fns';
 import { toIsoDate } from './format';
-import { fetchRates } from './fetchRates';
+import { fetchRates, type FetchedRate } from './fetchRates';
 import { addMoney, moneyFromString, mulMoney, subMoney, sumMoney, ZERO, type Money } from './money';
 
 export type Period = {
@@ -11,6 +11,7 @@ export type Period = {
 
 export const GAIN_FIELD = {
     Period: 'Period',
+    DateAcquired: 'Date Acquired',
     DateSold: 'Date Sold',
     Description: 'Description',
     Proceeds: 'Proceeds',
@@ -35,6 +36,7 @@ export type RecordType = 'Sell' | 'Summary';
 
 export type GainsType = {
     [GAIN_FIELD.Period]: Period;
+    [GAIN_FIELD.DateAcquired]: string;
     [GAIN_FIELD.DateSold]: string;
     [GAIN_FIELD.Description]: string;
     [GAIN_FIELD.Proceeds]: Money;
@@ -64,6 +66,7 @@ export interface VerificationData {
 
 export interface ExchangeRate {
     date: string;
+    rateDate: string;
     rate: Money;
 }
 
@@ -93,17 +96,18 @@ const findPeriod = (periods: Period[], date: Date): Period => {
 const buildGain = (
     row: EtradeData,
     periods: Period[],
-    rates: Record<string, Money>,
+    rates: Record<string, FetchedRate>,
 ): GainsType => {
     const dateSold = new Date(row[ETRADE_FIELD.DateSold]);
     const dateAcquired = new Date(row[ETRADE_FIELD.DateAcquired]);
     const proceedsUsd = parseMoney(row[ETRADE_FIELD.TotalProceeds]);
     const costBaseUsd = parseMoney(row[ETRADE_FIELD.AdjustedCostBasis]);
-    const proceeds = mulMoney(proceedsUsd, rates[toIsoDate(dateSold)]);
-    const costBase = mulMoney(costBaseUsd, rates[toIsoDate(dateAcquired)]);
+    const proceeds = mulMoney(proceedsUsd, rates[toIsoDate(dateSold)].rate);
+    const costBase = mulMoney(costBaseUsd, rates[toIsoDate(dateAcquired)].rate);
 
     return {
         [GAIN_FIELD.Period]: findPeriod(periods, dateSold),
+        [GAIN_FIELD.DateAcquired]: row[ETRADE_FIELD.DateAcquired],
         [GAIN_FIELD.DateSold]: row[ETRADE_FIELD.DateSold],
         [GAIN_FIELD.Description]: `${row[ETRADE_FIELD.Symbol]} ${row[ETRADE_FIELD.PlanType]}`,
         [GAIN_FIELD.Proceeds]: proceeds,
@@ -119,6 +123,7 @@ const totalForPeriod = (period: Period, gains: GainsType[]): GainsType => {
 
     return {
         [GAIN_FIELD.Period]: period,
+        [GAIN_FIELD.DateAcquired]: '',
         [GAIN_FIELD.DateSold]: '',
         [GAIN_FIELD.Description]: '',
         [GAIN_FIELD.Proceeds]: sum(GAIN_FIELD.Proceeds),
@@ -154,7 +159,7 @@ export const calculateTax = async (
     const { usdProceeds, usdGainLoss } = usdTotals(sales);
 
     const exchangeRates: ExchangeRate[] = Object.entries(rates)
-        .map(([date, rate]) => ({ date, rate }))
+        .map(([date, { rate, rateDate }]) => ({ date, rateDate, rate }))
         .sort((a, b) => a.date.localeCompare(b.date));
 
     return {

--- a/src/utils/fetchRates.spec.ts
+++ b/src/utils/fetchRates.spec.ts
@@ -14,6 +14,7 @@ const mockFetch = (body: unknown, ok = true, status = 200) =>
     );
 
 const obs = (d: string, v: string) => ({ d, FXUSDCAD: { v } });
+const r = (rate: bigint, rateDate: string) => ({ rate, rateDate });
 
 describe('fetchRates', () => {
     afterEach(() => {
@@ -31,8 +32,8 @@ describe('fetchRates', () => {
         const result = await fetchRates([new Date(2025, 2, 10), new Date(2025, 2, 11)]);
 
         expect(result).toEqual({
-            '2025-03-10': 1_374_500n,
-            '2025-03-11': 1_375_000n,
+            '2025-03-10': r(1_374_500n, '2025-03-10'),
+            '2025-03-11': r(1_375_000n, '2025-03-11'),
         });
     });
 
@@ -44,7 +45,7 @@ describe('fetchRates', () => {
         // Sunday — should fall back to Friday
         const result = await fetchRates([new Date(2025, 2, 16)]);
 
-        expect(result).toEqual({ '2025-03-16': 1_400_000n });
+        expect(result).toEqual({ '2025-03-16': r(1_400_000n, '2025-03-14') });
     });
 
     it('returns ZERO when no observation is found even after lookback', async () => {
@@ -53,7 +54,7 @@ describe('fetchRates', () => {
         // date far from any observation
         const result = await fetchRates([new Date(2025, 5, 1)]);
 
-        expect(result).toEqual({ '2025-06-01': 0n });
+        expect(result).toEqual({ '2025-06-01': r(0n, '2025-06-01') });
     });
 
     it('ignores observations without FXUSDCAD field', async () => {
@@ -66,7 +67,7 @@ describe('fetchRates', () => {
 
         const result = await fetchRates([new Date(2025, 2, 10)]);
 
-        expect(result).toEqual({ '2025-03-10': 1_370_000n });
+        expect(result).toEqual({ '2025-03-10': r(1_370_000n, '2025-03-09') });
     });
 
     it('throws on HTTP error', async () => {
@@ -95,6 +96,6 @@ describe('fetchRates', () => {
         const result = await fetchRates([date, date]);
 
         expect(Object.keys(result)).toEqual(['2025-03-10']);
-        expect(result['2025-03-10']).toBe(1_374_500n);
+        expect(result['2025-03-10']).toEqual(r(1_374_500n, '2025-03-10'));
     });
 });

--- a/src/utils/fetchRates.ts
+++ b/src/utils/fetchRates.ts
@@ -23,7 +23,12 @@ const findWithLookback = (observations: Observation[], date: Date): Observation 
     return undefined;
 };
 
-export const fetchRates = async (dates: Date[]): Promise<Record<string, Money>> => {
+export interface FetchedRate {
+    rate: Money;
+    rateDate: string;
+}
+
+export const fetchRates = async (dates: Date[]): Promise<Record<string, FetchedRate>> => {
     try {
         const response = await fetch(API_URL);
         if (!response.ok) {
@@ -35,7 +40,8 @@ export const fetchRates = async (dates: Date[]): Promise<Record<string, Money>> 
             dates.map(date => {
                 const observation = findWithLookback(data.observations, date);
                 const rate = observation?.FXUSDCAD ? moneyFromString(observation.FXUSDCAD.v) ?? ZERO : ZERO;
-                return [toIsoDate(date), rate];
+                const rateDate = observation?.d ?? toIsoDate(date);
+                return [toIsoDate(date), { rate, rateDate }];
             }),
         );
     } catch (error) {


### PR DESCRIPTION
- Track actual rate date in fetchRates to show when lookback was used
- Add Date Acquired column to transactions table
- Link each exchange rate to Bank of Canada lookup page for verification
- Muted transaction row numbers for cleaner appearance
- Update all tests for new data shapes