### PR TITLE
Add CRA definition tooltips and reporting link to tax summary

### DIFF
--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -1,7 +1,18 @@
 import { format } from 'date-fns';
 import { CSVLink } from 'react-csv';
+import { BoxArrowUpRight, InfoCircle } from 'react-bootstrap-icons';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { GAIN_FIELD, type GainsType, type Period } from '../utils/GainsCalculator';
 import { formatCurrency, gainClass } from '../utils/format';
+
+const CraTooltip = ({ text }: { text: string }) => (
+    <OverlayTrigger
+        placement="right"
+        overlay={<Tooltip className="cra-tooltip">{text}</Tooltip>}
+    >
+        <InfoCircle size={12} className="ms-1 text-muted" style={{ cursor: 'help' }} />
+    </OverlayTrigger>
+);
 import { formatMoney } from '../utils/money';
 
 interface TaxSummaryProps {
@@ -31,15 +42,26 @@ const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean 
                 </div>
             )}
             <div className="cra-row">
-                <span className="cra-row-label">Proceeds of disposition</span>
+                <span className="cra-row-label">
+                    Proceeds of disposition
+                    <CraTooltip text="This is usually the amount you received or will receive for your property. In most cases, it refers to the sale price of the property. This could also include compensation you received for property that has been destroyed, expropriated or stolen." />
+                </span>
                 <span className="cra-row-value">{formatCurrency(row[GAIN_FIELD.Proceeds])}</span>
             </div>
             <div className="cra-row">
-                <span className="cra-row-label">Adjusted cost base</span>
+                <span className="cra-row-label">
+                    Adjusted cost base
+                    <CraTooltip text="This is usually the cost of a property plus any expenses to acquire it, such as commissions and legal fees.
+
+The cost of a capital property is its actual or deemed cost, depending on the type of property and how you acquired it. It also includes capital expenditures, such as the cost of additions and improvements to the property. You cannot add current expenses, such as maintenance and repair costs, to the cost base of a property." />
+                </span>
                 <span className="cra-row-value">{formatCurrency(row[GAIN_FIELD.CostBase])}</span>
             </div>
             <div className="cra-row">
-                <span className="cra-row-label">Outlays and expenses</span>
+                <span className="cra-row-label">
+                    Outlays and expenses
+                    <CraTooltip text="These are amounts that you incurred to sell a capital property. You can deduct outlays and expenses from your proceeds of disposition when calculating your capital gain or loss. You cannot reduce your other income by claiming a deduction for these outlays and expenses. These types of expenses include fixing-up expenses, finders' fees, commissions, brokers' fees, surveyors' fees, legal fees, transfer taxes, and advertising costs." />
+                </span>
                 <span className="cra-row-value">{formatCurrency(row[GAIN_FIELD.Expenses])}</span>
             </div>
             <div className="cra-row cra-row-highlight">
@@ -62,7 +84,15 @@ const TaxSummary = ({ totals }: TaxSummaryProps) => {
             {totals.map((row, i) => (
                 <PeriodBlock key={i} row={row} showPeriod={showPeriod} />
             ))}
-            <div className="d-flex justify-content-end p-2">
+            <div className="d-flex justify-content-between align-items-center p-2">
+                <a
+                    href="https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/personal-income/line-12700-capital-gains/calculating-reporting-your-capital-gains-losses.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="small text-muted"
+                >
+                    CRA: Reporting capital gains/losses<BoxArrowUpRight size={10} className="ms-1" />
+                </a>
                 <CSVLink className="btn btn-sm btn-outline-primary" data={totals.map(toCsvRow)}>
                     Download CSV
                 </CSVLink>

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -80,6 +80,12 @@ body {
     opacity: 0.8;
 }
 
+.cra-tooltip .tooltip-inner {
+    max-width: 360px;
+    text-align: left;
+    white-space: pre-line;
+}
+
 .cra-period-title {
     background: #ecf0f1;
     padding: 8px 16px;


### PR DESCRIPTION
- Add info icon tooltips for Proceeds, Adjusted cost base, and Outlays and expenses with official CRA definitions
- Add link to CRA capital gains reporting page in card footer