### PR TITLE
visual polish, CRA tooltips, calculation breakdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: install start build preview test test-watch clean
+
+install:
+	npm install
+
+start:
+	npm start
+
+build:
+	npm run build
+
+preview:
+	npm run preview
+
+test:
+	npm test
+
+test-watch:
+	npm run test:watch
+
+clean:
+	rm -rf dist node_modules

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,12 @@ const periods: Period[] = [
 const App = () => {
     const [results, setResults] = useState<ResultsType | null>(null);
     const [summary, setSummary] = useState<EtradeData | null>(null);
+    const [sales, setSales] = useState<EtradeData[]>([]);
 
     const handleFileSelect = async (file: File) => {
         const parsed: ParseResult = await parseXls(file);
         setSummary(parsed.summary);
+        setSales(parsed.sales);
         const calculated = await calculateTax(parsed.sales, periods);
         setResults(calculated);
     };
@@ -23,12 +25,13 @@ const App = () => {
     const handleReset = () => {
         setResults(null);
         setSummary(null);
+        setSales([]);
     };
 
     return (
         <div className="App">
             {results ? (
-                <ResultsPage results={results} summary={summary} onReset={handleReset} />
+                <ResultsPage results={results} summary={summary} sales={sales} onReset={handleReset} />
             ) : (
                 <LandingPage onFileSelect={handleFileSelect} />
             )}

--- a/src/components/CalculationBreakdown.tsx
+++ b/src/components/CalculationBreakdown.tsx
@@ -1,0 +1,129 @@
+import { Accordion, Table } from 'react-bootstrap';
+import { BoxArrowUpRight } from 'react-bootstrap-icons';
+import { ETRADE_FIELD, GAIN_FIELD, type EtradeData, type ExchangeRate, type GainsType } from '../utils/GainsCalculator';
+import { formatCurrency, formatDate, gainClass } from '../utils/format';
+import { formatMoney, moneyFromString, ZERO } from '../utils/money';
+
+const bocUrl = (date: string) =>
+    `https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates-lookup/?lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&series%5B%5D=FXUSDCAD&lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&rangeType=range&rangeValue=&dFrom=${date}&dTo=&submit_button=Submit`;
+
+const RateLink = ({ rate }: { rate: ExchangeRate }) => (
+    <a href={bocUrl(rate.rateDate)} target="_blank" rel="noopener noreferrer" className="text-decoration-none">
+        {formatMoney(rate.rate, { decimals: 4 })} <BoxArrowUpRight size={10} className="text-muted" />
+    </a>
+);
+
+interface CalculationBreakdownProps {
+    sales: EtradeData[];
+    gains: GainsType[];
+    exchangeRates: ExchangeRate[];
+}
+
+const findRate = (rates: ExchangeRate[], dateStr: string): ExchangeRate | undefined => {
+    const date = new Date(dateStr);
+    const iso = date.toISOString().split('T')[0];
+    return rates.find(r => r.date === iso);
+};
+
+const CalculationBreakdown = ({ sales, gains, exchangeRates }: CalculationBreakdownProps) => {
+    return (
+        <Accordion>
+            {sales.map((sale, i) => {
+                const gain = gains[i];
+                const proceedsUsd = moneyFromString(sale[ETRADE_FIELD.TotalProceeds]) ?? ZERO;
+                const costBaseUsd = moneyFromString(sale[ETRADE_FIELD.AdjustedCostBasis]) ?? ZERO;
+                const rateSold = findRate(exchangeRates, sale[ETRADE_FIELD.DateSold]);
+                const rateAcquired = findRate(exchangeRates, sale[ETRADE_FIELD.DateAcquired]);
+
+                return (
+                    <Accordion.Item eventKey={String(i)} key={i}>
+                        <Accordion.Header>
+                            <span className="d-flex w-100 align-items-center">
+                                <span className="text-muted" style={{ width: '2rem' }}>#{i + 1}</span>
+                                <span style={{ width: '7rem' }}>{sale[ETRADE_FIELD.Symbol]} {sale[ETRADE_FIELD.PlanType]}</span>
+                                <span className="text-muted">
+                                    sold {formatDate(sale[ETRADE_FIELD.DateSold])}
+                                </span>
+                                {gain && (
+                                    <span className={`ms-auto me-2 fw-semibold ${gainClass(gain[GAIN_FIELD.GainLoss])}`}>
+                                        {formatCurrency(gain[GAIN_FIELD.GainLoss])}
+                                    </span>
+                                )}
+                            </span>
+                        </Accordion.Header>
+                        <Accordion.Body>
+                            <Table size="sm" bordered className="transactions-table mb-0">
+                                <tbody>
+                                    <tr>
+                                        <td colSpan={3} className="text-muted fw-semibold bg-light">Proceeds</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Total Proceeds (USD)</td>
+                                        <td colSpan={2}>{formatMoney(proceedsUsd, { decimals: 2, grouping: true })}</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Date Sold</td>
+                                        <td colSpan={2}>
+                                            {formatDate(sale[ETRADE_FIELD.DateSold])}
+                                            {rateSold && rateSold.date !== rateSold.rateDate && (
+                                                <span className="text-muted small ms-1">(rate from {formatDate(rateSold.rateDate)})</span>
+                                            )}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Exchange Rate ({rateSold ? formatDate(rateSold.rateDate) : 'N/A'})</td>
+                                        <td colSpan={2}>{rateSold ? <RateLink rate={rateSold} /> : 'N/A'}</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Proceeds (CAD)</td>
+                                        <td>{formatMoney(proceedsUsd, { decimals: 2, grouping: true })} &times; {rateSold ? formatMoney(rateSold.rate, { decimals: 4 }) : '?'}</td>
+                                        <td className="fw-semibold">{gain ? formatCurrency(gain[GAIN_FIELD.Proceeds]) : 'N/A'}</td>
+                                    </tr>
+
+                                    <tr>
+                                        <td colSpan={3} className="text-muted fw-semibold bg-light">Cost Base</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Adjusted Cost Basis (USD)</td>
+                                        <td colSpan={2}>{formatMoney(costBaseUsd, { decimals: 2, grouping: true })}</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Date Acquired</td>
+                                        <td colSpan={2}>
+                                            {formatDate(sale[ETRADE_FIELD.DateAcquired])}
+                                            {rateAcquired && rateAcquired.date !== rateAcquired.rateDate && (
+                                                <span className="text-muted small ms-1">(rate from {formatDate(rateAcquired.rateDate)})</span>
+                                            )}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Exchange Rate ({rateAcquired ? formatDate(rateAcquired.rateDate) : 'N/A'})</td>
+                                        <td colSpan={2}>{rateAcquired ? <RateLink rate={rateAcquired} /> : 'N/A'}</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Cost Base (CAD)</td>
+                                        <td>{formatMoney(costBaseUsd, { decimals: 2, grouping: true })} &times; {rateAcquired ? formatMoney(rateAcquired.rate, { decimals: 4 }) : '?'}</td>
+                                        <td className="fw-semibold">{gain ? formatCurrency(gain[GAIN_FIELD.CostBase]) : 'N/A'}</td>
+                                    </tr>
+
+                                    <tr>
+                                        <td colSpan={3} className="text-muted fw-semibold bg-light">Result</td>
+                                    </tr>
+                                    <tr>
+                                        <td className="text-muted">Gain (Loss) CAD</td>
+                                        <td>{gain ? `${formatCurrency(gain[GAIN_FIELD.Proceeds])} \u2212 ${formatCurrency(gain[GAIN_FIELD.CostBase])}` : ''}</td>
+                                        <td className={`fw-semibold ${gain ? gainClass(gain[GAIN_FIELD.GainLoss]) : ''}`}>
+                                            {gain ? formatCurrency(gain[GAIN_FIELD.GainLoss]) : 'N/A'}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </Table>
+                        </Accordion.Body>
+                    </Accordion.Item>
+                );
+            })}
+        </Accordion>
+    );
+};
+
+export default CalculationBreakdown;

--- a/src/components/DataVerification.tsx
+++ b/src/components/DataVerification.tsx
@@ -1,5 +1,6 @@
 import { Accordion, Table } from 'react-bootstrap';
 import { CheckLg, ExclamationTriangleFill } from 'react-bootstrap-icons';
+import CalculationBreakdown from './CalculationBreakdown';
 import ExchangeRatesTable from './ExchangeRatesTable';
 import TransactionsTable from './TransactionsTable';
 import { ETRADE_FIELD, type EtradeData, type ExchangeRate, type GainsType, type VerificationData } from '../utils/GainsCalculator';
@@ -9,6 +10,7 @@ import { moneyFromString, subMoney, type Money } from '../utils/money';
 interface DataVerificationProps {
     verification: VerificationData;
     summary: EtradeData | null;
+    sales: EtradeData[];
     exchangeRates: ExchangeRate[];
     gains: GainsType[];
 }
@@ -46,7 +48,7 @@ const SummaryRow = ({ data }: { data: EtradeData }) => {
     );
 };
 
-const DataVerification = ({ verification, summary, exchangeRates, gains }: DataVerificationProps) => {
+const DataVerification = ({ verification, summary, sales, exchangeRates, gains }: DataVerificationProps) => {
     const crossChecks: CrossCheckRow[] = [];
 
     if (summary) {
@@ -86,6 +88,21 @@ const DataVerification = ({ verification, summary, exchangeRates, gains }: DataV
                         </Accordion.Header>
                         <Accordion.Body>
                             <TransactionsTable data={gains} />
+                        </Accordion.Body>
+                    </Accordion.Item>
+                </Accordion>
+
+                <div className="verification-item">
+                    <CheckIcon />
+                    <span>Calculation breakdown</span>
+                </div>
+                <Accordion className="ms-4 mb-2">
+                    <Accordion.Item eventKey="breakdown">
+                        <Accordion.Header>
+                            Calculation Details <span className="verification-badge">{gains.length}</span>
+                        </Accordion.Header>
+                        <Accordion.Body>
+                            <CalculationBreakdown sales={sales} gains={gains} exchangeRates={exchangeRates} />
                         </Accordion.Body>
                     </Accordion.Item>
                 </Accordion>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -6,10 +6,11 @@ import type { EtradeData, ResultsType } from '../utils/GainsCalculator';
 interface ResultsPageProps {
     results: ResultsType;
     summary: EtradeData | null;
+    sales: EtradeData[];
     onReset: () => void;
 }
 
-const ResultsPage = ({ results, summary, onReset }: ResultsPageProps) => {
+const ResultsPage = ({ results, summary, sales, onReset }: ResultsPageProps) => {
     return (
         <div className="container results-container">
             <div className="d-flex justify-content-between align-items-center py-4">
@@ -26,6 +27,7 @@ const ResultsPage = ({ results, summary, onReset }: ResultsPageProps) => {
             <DataVerification
                 verification={results.verification}
                 summary={summary}
+                sales={sales}
                 exchangeRates={results.exchangeRates}
                 gains={results.gains}
             />

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -10,7 +10,10 @@ export const formatCurrency = (value: Money): string => {
 
 export const toIsoDate = (date: Date): string => format(date, ISO_DATE);
 
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 export const formatDate = (value: string): string => {
+    if (ISO_DATE_RE.test(value)) return value;
     const date = new Date(value);
     return isValid(date) ? format(date, ISO_DATE) : value;
 };


### PR DESCRIPTION
## Summary
- Replace inline SVGs/emojis with `react-bootstrap-icons`; switch landing headline to Plus Jakarta Sans and apply blue-accent visual polish (back arrow, rebrand).
- Add CRA definition tooltips, BoC exchange-rate links, `Date Acquired` column, and a per-transaction calculation breakdown so users can verify how each gain is derived.
- Fix `formatDate` timezone shift for ISO date strings; add `Makefile` with install/start/build/test/clean targets; update README, `.gitignore`, and add eTrade link to landing page.
