### PR TITLE
feat: download Calculation Breakdown as CSV

### DIFF
--- a/src/components/CalculationBreakdown.tsx
+++ b/src/components/CalculationBreakdown.tsx
@@ -1,18 +1,9 @@
 import { Accordion, Table } from 'react-bootstrap';
-import { BoxArrowUpRight } from 'react-bootstrap-icons';
 import { CSVLink } from 'react-csv';
+import RateLink from './RateLink';
 import { ETRADE_FIELD, GAIN_FIELD, type EtradeData, type ExchangeRate, type GainsType } from '../utils/GainsCalculator';
 import { formatCurrency, formatDate, gainClass } from '../utils/format';
 import { formatMoney, moneyFromString, ZERO } from '../utils/money';
-
-const bocUrl = (date: string) =>
-    `https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates-lookup/?lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&series%5B%5D=FXUSDCAD&lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&rangeType=range&rangeValue=&dFrom=${date}&dTo=&submit_button=Submit`;
-
-const RateLink = ({ rate }: { rate: ExchangeRate }) => (
-    <a href={bocUrl(rate.rateDate)} target="_blank" rel="noopener noreferrer" className="text-decoration-none">
-        {formatMoney(rate.rate, { decimals: 4 })} <BoxArrowUpRight size={10} className="text-muted" />
-    </a>
-);
 
 interface CalculationBreakdownProps {
     sales: EtradeData[];

--- a/src/components/CalculationBreakdown.tsx
+++ b/src/components/CalculationBreakdown.tsx
@@ -1,4 +1,5 @@
 import { Accordion, Table } from 'react-bootstrap';
+import { CheckLg } from 'react-bootstrap-icons';
 import { CSVLink } from 'react-csv';
 import RateLink from './RateLink';
 import { ETRADE_FIELD, GAIN_FIELD, type EtradeData, type ExchangeRate, type GainsType } from '../utils/GainsCalculator';
@@ -43,13 +44,23 @@ const CalculationBreakdown = ({ sales, gains, exchangeRates }: CalculationBreakd
     const csvData = sales.map((sale, i) => toCsvRow(sale, gains[i], exchangeRates));
 
     return (
-        <div>
-            <div className="mb-3 text-end">
-                <CSVLink className="btn btn-sm btn-outline-primary" data={csvData} filename="calculation-breakdown.csv">
-                    Download CSV
-                </CSVLink>
+        <>
+            <div className="verification-item">
+                <CheckLg className="verification-check" />
+                <span>Calculation Breakdown</span>
             </div>
-            <Accordion>
+            <Accordion className="ms-4 mb-2">
+                <Accordion.Item eventKey="breakdown">
+                    <Accordion.Header>
+                        Calculation Details <span className="verification-badge">{gains.length}</span>
+                    </Accordion.Header>
+                    <Accordion.Body>
+                        <div className="mb-3 text-end">
+                            <CSVLink className="btn btn-sm btn-outline-primary" data={csvData} filename="calculation-breakdown.csv">
+                                Download CSV
+                            </CSVLink>
+                        </div>
+                        <Accordion>
             {sales.map((sale, i) => {
                 const gain = gains[i];
                 const proceedsUsd = moneyFromString(sale[ETRADE_FIELD.TotalProceeds]) ?? ZERO;
@@ -144,8 +155,11 @@ const CalculationBreakdown = ({ sales, gains, exchangeRates }: CalculationBreakd
                     </Accordion.Item>
                 );
             })}
+                        </Accordion>
+                    </Accordion.Body>
+                </Accordion.Item>
             </Accordion>
-        </div>
+        </>
     );
 };
 

--- a/src/components/CalculationBreakdown.tsx
+++ b/src/components/CalculationBreakdown.tsx
@@ -1,5 +1,6 @@
 import { Accordion, Table } from 'react-bootstrap';
 import { BoxArrowUpRight } from 'react-bootstrap-icons';
+import { CSVLink } from 'react-csv';
 import { ETRADE_FIELD, GAIN_FIELD, type EtradeData, type ExchangeRate, type GainsType } from '../utils/GainsCalculator';
 import { formatCurrency, formatDate, gainClass } from '../utils/format';
 import { formatMoney, moneyFromString, ZERO } from '../utils/money';
@@ -25,9 +26,39 @@ const findRate = (rates: ExchangeRate[], dateStr: string): ExchangeRate | undefi
     return rates.find(r => r.date === iso);
 };
 
+const toCsvRow = (sale: EtradeData, gain: GainsType | undefined, rates: ExchangeRate[]) => {
+    const proceedsUsd = moneyFromString(sale[ETRADE_FIELD.TotalProceeds]) ?? ZERO;
+    const costBaseUsd = moneyFromString(sale[ETRADE_FIELD.AdjustedCostBasis]) ?? ZERO;
+    const rateSold = findRate(rates, sale[ETRADE_FIELD.DateSold]);
+    const rateAcquired = findRate(rates, sale[ETRADE_FIELD.DateAcquired]);
+    return {
+        'Symbol': sale[ETRADE_FIELD.Symbol],
+        'Plan Type': sale[ETRADE_FIELD.PlanType],
+        'Date Acquired': formatDate(sale[ETRADE_FIELD.DateAcquired]),
+        'Cost Basis (USD)': formatMoney(costBaseUsd, { decimals: 2 }),
+        'Rate Date (Acquired)': rateAcquired?.rateDate ?? '',
+        'Exchange Rate (Acquired)': rateAcquired ? formatMoney(rateAcquired.rate, { decimals: 4 }) : '',
+        'Cost Base (CAD)': gain ? formatMoney(gain[GAIN_FIELD.CostBase], { decimals: 2 }) : '',
+        'Date Sold': formatDate(sale[ETRADE_FIELD.DateSold]),
+        'Proceeds (USD)': formatMoney(proceedsUsd, { decimals: 2 }),
+        'Rate Date (Sold)': rateSold?.rateDate ?? '',
+        'Exchange Rate (Sold)': rateSold ? formatMoney(rateSold.rate, { decimals: 4 }) : '',
+        'Proceeds (CAD)': gain ? formatMoney(gain[GAIN_FIELD.Proceeds], { decimals: 2 }) : '',
+        'Gain/Loss (CAD)': gain ? formatMoney(gain[GAIN_FIELD.GainLoss], { decimals: 2 }) : '',
+    };
+};
+
 const CalculationBreakdown = ({ sales, gains, exchangeRates }: CalculationBreakdownProps) => {
+    const csvData = sales.map((sale, i) => toCsvRow(sale, gains[i], exchangeRates));
+
     return (
-        <Accordion>
+        <div>
+            <div className="mb-3 text-end">
+                <CSVLink className="btn btn-sm btn-outline-primary" data={csvData} filename="calculation-breakdown.csv">
+                    Download CSV
+                </CSVLink>
+            </div>
+            <Accordion>
             {sales.map((sale, i) => {
                 const gain = gains[i];
                 const proceedsUsd = moneyFromString(sale[ETRADE_FIELD.TotalProceeds]) ?? ZERO;
@@ -122,7 +153,8 @@ const CalculationBreakdown = ({ sales, gains, exchangeRates }: CalculationBreakd
                     </Accordion.Item>
                 );
             })}
-        </Accordion>
+            </Accordion>
+        </div>
     );
 };
 

--- a/src/components/DataVerification.tsx
+++ b/src/components/DataVerification.tsx
@@ -92,20 +92,7 @@ const DataVerification = ({ verification, summary, sales, exchangeRates, gains }
                     </Accordion.Item>
                 </Accordion>
 
-                <div className="verification-item">
-                    <CheckIcon />
-                    <span>Calculation Breakdown</span>
-                </div>
-                <Accordion className="ms-4 mb-2">
-                    <Accordion.Item eventKey="breakdown">
-                        <Accordion.Header>
-                            Calculation Details <span className="verification-badge">{gains.length}</span>
-                        </Accordion.Header>
-                        <Accordion.Body>
-                            <CalculationBreakdown sales={sales} gains={gains} exchangeRates={exchangeRates} />
-                        </Accordion.Body>
-                    </Accordion.Item>
-                </Accordion>
+                <CalculationBreakdown sales={sales} gains={gains} exchangeRates={exchangeRates} />
 
                 {summary && (
                     <>

--- a/src/components/DataVerification.tsx
+++ b/src/components/DataVerification.tsx
@@ -94,7 +94,7 @@ const DataVerification = ({ verification, summary, sales, exchangeRates, gains }
 
                 <div className="verification-item">
                     <CheckIcon />
-                    <span>Calculation breakdown</span>
+                    <span>Calculation Breakdown</span>
                 </div>
                 <Accordion className="ms-4 mb-2">
                     <Accordion.Item eventKey="breakdown">

--- a/src/components/ExchangeRatesTable.tsx
+++ b/src/components/ExchangeRatesTable.tsx
@@ -1,11 +1,7 @@
 import { Table } from 'react-bootstrap';
-import { BoxArrowUpRight } from 'react-bootstrap-icons';
+import RateLink from './RateLink';
 import type { ExchangeRate } from '../utils/GainsCalculator';
 import { formatDate } from '../utils/format';
-import { formatMoney } from '../utils/money';
-
-const bocUrl = (date: string) =>
-    `https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates-lookup/?lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&series%5B%5D=FXUSDCAD&lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&rangeType=range&rangeValue=&dFrom=${date}&dTo=&submit_button=Submit`;
 
 interface ExchangeRatesTableProps {
     rates: ExchangeRate[];
@@ -34,15 +30,7 @@ const ExchangeRatesTable = ({ rates }: ExchangeRatesTableProps) => {
                                 {lookback && <span className="text-muted ms-1 small">(rate from {formatDate(r.rateDate)})</span>}
                             </td>
                             <td className="text-end" style={{ fontFamily: "'Courier New', monospace" }}>
-                                <a
-                                    href={bocUrl(r.rateDate)}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="text-decoration-none"
-                                >
-                                    {formatMoney(r.rate, { decimals: 4 })}
-                                    &nbsp;<BoxArrowUpRight size={10} className="text-muted" />
-                                </a>
+                                <RateLink rate={r} />
                             </td>
                         </tr>
                     );

--- a/src/components/RateLink.tsx
+++ b/src/components/RateLink.tsx
@@ -1,0 +1,16 @@
+import { BoxArrowUpRight } from 'react-bootstrap-icons';
+import { bocLookupUrl } from '../utils/boc';
+import type { ExchangeRate } from '../utils/GainsCalculator';
+import { formatMoney } from '../utils/money';
+
+interface RateLinkProps {
+    rate: ExchangeRate;
+}
+
+const RateLink = ({ rate }: RateLinkProps) => (
+    <a href={bocLookupUrl(rate.rateDate)} target="_blank" rel="noopener noreferrer" className="text-decoration-none">
+        {formatMoney(rate.rate, { decimals: 4 })}&nbsp;<BoxArrowUpRight size={10} className="text-muted" />
+    </a>
+);
+
+export default RateLink;

--- a/src/utils/boc.ts
+++ b/src/utils/boc.ts
@@ -1,0 +1,4 @@
+export const BOC_VALET_URL = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
+
+export const bocLookupUrl = (date: string) =>
+    `https://www.bankofcanada.ca/rates/exchange/daily-exchange-rates-lookup/?lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&series%5B%5D=FXUSDCAD&lookupPage=lookup_daily_exchange_rates_2017.php&startRange=2017-01-01&rangeType=range&rangeValue=&dFrom=${date}&dTo=&submit_button=Submit`;

--- a/src/utils/fetchRates.ts
+++ b/src/utils/fetchRates.ts
@@ -1,4 +1,5 @@
 import { subDays } from 'date-fns';
+import { BOC_VALET_URL } from './boc';
 import { toIsoDate } from './format';
 import { moneyFromString, ZERO, type Money } from './money';
 
@@ -7,7 +8,6 @@ interface Observation {
     FXUSDCAD?: { v: string };
 }
 
-const API_URL = 'https://www.bankofcanada.ca/valet/observations/FXUSDCAD/json';
 const MAX_LOOKBACK_DAYS = 2;
 
 const findObservation = (observations: Observation[], date: Date): Observation | undefined => {
@@ -30,7 +30,7 @@ export interface FetchedRate {
 
 export const fetchRates = async (dates: Date[]): Promise<Record<string, FetchedRate>> => {
     try {
-        const response = await fetch(API_URL);
+        const response = await fetch(BOC_VALET_URL);
         if (!response.ok) {
             throw new Error(`HTTP error: ${response.status}`);
         }


### PR DESCRIPTION
## Summary
- Add a `Download CSV` button to the Calculation Breakdown section, following the `react-csv` pattern used by `TransactionsTable` and `TaxSummary`; exports one row per sale with symbol, plan type, acquired/sold dates, USD amounts, exchange rates (and rate-dates), CAD amounts, and gain/loss.
- Fix label casing: "Calculation breakdown" → "Calculation Breakdown".
- Extract shared `bocLookupUrl`/`BOC_VALET_URL` helpers (`src/utils/boc.ts`) and shared `RateLink` component — previously duplicated across `CalculationBreakdown`, `ExchangeRatesTable`, and `fetchRates`.
- Encapsulate the Calculation Breakdown section wrapping (verification-item header + outer Accordion) inside `CalculationBreakdown`, so `DataVerification` no longer carries that chrome.
