### PR TITLE
chore(devcontainer): remove ~/.ssh mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
   "forwardPorts": [3000],
   "postCreateCommand": "npm install",
   "mounts": [
-    "source=${localEnv:HOME}/.ssh,target=/home/node/.ssh,type=bind,readonly",
     "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind"
   ],
   "customizations": {


### PR DESCRIPTION
The host SSH config can include macOS-only options (e.g. UseKeychain) that break ssh inside the Linux container. Drop the mount; users who need SSH inside the container can configure it explicitly.