### PR TITLE
feat(results): toggle totals/per-transaction views with row copy

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,20 @@
+import { CheckCircleFill } from 'react-bootstrap-icons';
+
+interface CopyButtonProps {
+    copied: boolean;
+    onClick: () => void;
+}
+
+const CopyButton = ({ copied, onClick }: CopyButtonProps) => (
+    <button
+        type="button"
+        className="btn btn-sm btn-outline-primary d-inline-flex align-items-center"
+        onClick={onClick}
+        title="Copy Proceeds, ACB, Outlays as tab-separated values"
+    >
+        {copied && <CheckCircleFill size={12} className="me-1 text-success" />}
+        <span>{copied ? 'Copied' : 'Copy'}</span>
+    </button>
+);
+
+export default CopyButton;

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -22,7 +22,7 @@ const ResultsPage = ({ results, summary, sales, onReset }: ResultsPageProps) => 
                 </button>
             </div>
 
-            <TaxSummary totals={results.total} />
+            <TaxSummary totals={results.total} gains={results.gains} />
 
             <DataVerification
                 verification={results.verification}

--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
 import { CSVLink } from 'react-csv';
-import { BoxArrowUpRight, CheckCircleFill, InfoCircle } from 'react-bootstrap-icons';
-import { OverlayTrigger, Table, Tooltip } from 'react-bootstrap';
+import { BoxArrowUpRight, InfoCircle } from 'react-bootstrap-icons';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import CopyButton from './CopyButton';
+import TransactionsView from './TransactionsView';
 import { GAIN_FIELD, type GainsType, type Period } from '../utils/GainsCalculator';
 import { formatCurrency, gainClass } from '../utils/format';
 import { formatMoney } from '../utils/money';
@@ -16,18 +18,6 @@ const copyRowToClipboard = async (name: string, row: GainsType): Promise<void> =
     ].join('\t');
     await navigator.clipboard.writeText(tsv);
 };
-
-const CopyButton = ({ copied, onClick }: { copied: boolean; onClick: () => void }) => (
-    <button
-        type="button"
-        className="btn btn-sm btn-outline-primary d-inline-flex align-items-center"
-        onClick={onClick}
-        title="Copy Proceeds, ACB, Outlays as tab-separated values"
-    >
-        {copied && <CheckCircleFill size={12} className="me-1 text-success" />}
-        <span>{copied ? 'Copied' : 'Copy'}</span>
-    </button>
-);
 
 type View = 'totals' | 'transactions';
 
@@ -102,43 +92,6 @@ The cost of a capital property is its actual or deemed cost, depending on the ty
         </div>
     );
 };
-
-interface TransactionsViewProps {
-    rows: GainsType[];
-    isCopied: (i: number) => boolean;
-    onCopy: (i: number) => void;
-}
-
-const TransactionsView = ({ rows, isCopied, onCopy }: TransactionsViewProps) => (
-    <Table responsive hover size="sm" className="cra-table mb-0">
-        <thead>
-            <tr>
-                <th>Transaction</th>
-                <th className="text-end">Proceeds of disposition</th>
-                <th className="text-end">Adjusted cost base</th>
-                <th className="text-end">Outlays and expenses</th>
-                <th className="text-end">Gain (Loss)</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            {rows.map((row, i) => {
-                const gainLoss = row[GAIN_FIELD.GainLoss];
-                const copied = isCopied(i);
-                return (
-                    <tr key={i} className={copied ? 'cra-block-copied' : ''}>
-                        <td>{row[GAIN_FIELD.Description]}</td>
-                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.Proceeds])}</td>
-                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.CostBase])}</td>
-                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.Expenses])}</td>
-                        <td className={`text-end cra-table-value ${gainClass(gainLoss)}`}>{formatCurrency(gainLoss)}</td>
-                        <td className="text-end"><CopyButton copied={copied} onClick={() => onCopy(i)} /></td>
-                    </tr>
-                );
-            })}
-        </tbody>
-    </Table>
-);
 
 const TaxSummary = ({ totals, gains }: TaxSummaryProps) => {
     const [view, setView] = useState<View>('totals');

--- a/src/components/TaxSummary.tsx
+++ b/src/components/TaxSummary.tsx
@@ -1,9 +1,35 @@
+import { useState } from 'react';
 import { format } from 'date-fns';
 import { CSVLink } from 'react-csv';
-import { BoxArrowUpRight, InfoCircle } from 'react-bootstrap-icons';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { BoxArrowUpRight, CheckCircleFill, InfoCircle } from 'react-bootstrap-icons';
+import { OverlayTrigger, Table, Tooltip } from 'react-bootstrap';
 import { GAIN_FIELD, type GainsType, type Period } from '../utils/GainsCalculator';
 import { formatCurrency, gainClass } from '../utils/format';
+import { formatMoney } from '../utils/money';
+
+const copyRowToClipboard = async (name: string, row: GainsType): Promise<void> => {
+    const tsv = [
+        name,
+        formatMoney(row[GAIN_FIELD.Proceeds]),
+        formatMoney(row[GAIN_FIELD.CostBase]),
+        formatMoney(row[GAIN_FIELD.Expenses]),
+    ].join('\t');
+    await navigator.clipboard.writeText(tsv);
+};
+
+const CopyButton = ({ copied, onClick }: { copied: boolean; onClick: () => void }) => (
+    <button
+        type="button"
+        className="btn btn-sm btn-outline-primary d-inline-flex align-items-center"
+        onClick={onClick}
+        title="Copy Proceeds, ACB, Outlays as tab-separated values"
+    >
+        {copied && <CheckCircleFill size={12} className="me-1 text-success" />}
+        <span>{copied ? 'Copied' : 'Copy'}</span>
+    </button>
+);
+
+type View = 'totals' | 'transactions';
 
 const CraTooltip = ({ text }: { text: string }) => (
     <OverlayTrigger
@@ -13,14 +39,14 @@ const CraTooltip = ({ text }: { text: string }) => (
         <InfoCircle size={12} className="ms-1 text-muted" style={{ cursor: 'help' }} />
     </OverlayTrigger>
 );
-import { formatMoney } from '../utils/money';
 
 interface TaxSummaryProps {
     totals: GainsType[];
+    gains: GainsType[];
 }
 
 const formatPeriodDates = (period: Period): string =>
-    `${format(period.start, 'MMM d')} \u2013 ${format(period.end, 'MMM d, yyyy')}`;
+    `${format(period.start, 'MMM d')} – ${format(period.end, 'MMM d, yyyy')}`;
 
 const toCsvRow = (row: GainsType) => ({
     [GAIN_FIELD.Period]: row[GAIN_FIELD.Period].name,
@@ -30,17 +56,19 @@ const toCsvRow = (row: GainsType) => ({
     [GAIN_FIELD.GainLoss]: formatMoney(row[GAIN_FIELD.GainLoss]),
 });
 
-const PeriodBlock = ({ row, showPeriod }: { row: GainsType; showPeriod: boolean }) => {
-    const period = row[GAIN_FIELD.Period];
+interface CraBlockProps {
+    row: GainsType;
+    title: string | null;
+    copied: boolean;
+    onCopy: () => void;
+}
+
+const CraBlock = ({ row, title, copied, onCopy }: CraBlockProps) => {
     const gainLoss = row[GAIN_FIELD.GainLoss];
 
     return (
-        <>
-            {showPeriod && (
-                <div className="cra-period-title">
-                    {period.name} &middot; {formatPeriodDates(period)}
-                </div>
-            )}
+        <div className={`cra-block ${copied ? 'cra-block-copied' : ''}`}>
+            {title && <div className="cra-period-title">{title}</div>}
             <div className="cra-row">
                 <span className="cra-row-label">
                     Proceeds of disposition
@@ -68,12 +96,60 @@ The cost of a capital property is its actual or deemed cost, depending on the ty
                 <span className="cra-row-label">Gain (Loss)</span>
                 <span className={`cra-row-value ${gainClass(gainLoss)}`}>{formatCurrency(gainLoss)}</span>
             </div>
-        </>
+            <div className="cra-block-actions">
+                <CopyButton copied={copied} onClick={onCopy} />
+            </div>
+        </div>
     );
 };
 
-const TaxSummary = ({ totals }: TaxSummaryProps) => {
+interface TransactionsViewProps {
+    rows: GainsType[];
+    isCopied: (i: number) => boolean;
+    onCopy: (i: number) => void;
+}
+
+const TransactionsView = ({ rows, isCopied, onCopy }: TransactionsViewProps) => (
+    <Table responsive hover size="sm" className="cra-table mb-0">
+        <thead>
+            <tr>
+                <th>Transaction</th>
+                <th className="text-end">Proceeds of disposition</th>
+                <th className="text-end">Adjusted cost base</th>
+                <th className="text-end">Outlays and expenses</th>
+                <th className="text-end">Gain (Loss)</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {rows.map((row, i) => {
+                const gainLoss = row[GAIN_FIELD.GainLoss];
+                const copied = isCopied(i);
+                return (
+                    <tr key={i} className={copied ? 'cra-block-copied' : ''}>
+                        <td>{row[GAIN_FIELD.Description]}</td>
+                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.Proceeds])}</td>
+                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.CostBase])}</td>
+                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.Expenses])}</td>
+                        <td className={`text-end cra-table-value ${gainClass(gainLoss)}`}>{formatCurrency(gainLoss)}</td>
+                        <td className="text-end"><CopyButton copied={copied} onClick={() => onCopy(i)} /></td>
+                    </tr>
+                );
+            })}
+        </tbody>
+    </Table>
+);
+
+const TaxSummary = ({ totals, gains }: TaxSummaryProps) => {
+    const [view, setView] = useState<View>('totals');
+    const [copiedKeys, setCopiedKeys] = useState<Set<string>>(new Set());
     const showPeriod = totals.length > 1;
+    const csvRows = view === 'totals' ? totals : gains;
+
+    const handleCopy = async (key: string, name: string, row: GainsType) => {
+        await copyRowToClipboard(name, row);
+        setCopiedKeys(prev => new Set(prev).add(key));
+    };
 
     return (
         <div className="cra-card mb-4">
@@ -81,9 +157,46 @@ const TaxSummary = ({ totals }: TaxSummaryProps) => {
                 Schedule 3 &mdash; Capital Gains (Losses)
                 <span className="cra-header-note">Values converted to CAD using Bank of Canada exchange rates</span>
             </div>
-            {totals.map((row, i) => (
-                <PeriodBlock key={i} row={row} showPeriod={showPeriod} />
-            ))}
+            <div className="cra-toolbar">
+                <div className="btn-group btn-group-sm" role="group" aria-label="View toggle">
+                    <button
+                        type="button"
+                        className={`btn btn-outline-secondary ${view === 'totals' ? 'active' : ''}`}
+                        onClick={() => setView('totals')}
+                    >
+                        Totals by period
+                    </button>
+                    <button
+                        type="button"
+                        className={`btn btn-outline-secondary ${view === 'transactions' ? 'active' : ''}`}
+                        onClick={() => setView('transactions')}
+                    >
+                        Per transaction
+                    </button>
+                </div>
+            </div>
+            {view === 'totals' ? (
+                totals.map((row, i) => {
+                    const period = row[GAIN_FIELD.Period];
+                    const title = showPeriod ? `${period.name} · ${formatPeriodDates(period)}` : null;
+                    const key = `p-${period.name}`;
+                    return (
+                        <CraBlock
+                            key={i}
+                            row={row}
+                            title={title}
+                            copied={copiedKeys.has(key)}
+                            onCopy={() => handleCopy(key, period.name, row)}
+                        />
+                    );
+                })
+            ) : (
+                <TransactionsView
+                    rows={gains}
+                    isCopied={(i) => copiedKeys.has(`t-${i}`)}
+                    onCopy={(i) => handleCopy(`t-${i}`, gains[i][GAIN_FIELD.Description], gains[i])}
+                />
+            )}
             <div className="d-flex justify-content-between align-items-center" style={{ padding: '10px 16px' }}>
                 <a
                     href="https://www.canada.ca/en/revenue-agency/services/tax/individuals/topics/about-your-tax-return/tax-return/completing-a-tax-return/personal-income/line-12700-capital-gains/calculating-reporting-your-capital-gains-losses.html"
@@ -93,7 +206,7 @@ const TaxSummary = ({ totals }: TaxSummaryProps) => {
                 >
                     CRA: Reporting capital gains/losses<BoxArrowUpRight size={10} className="ms-1" />
                 </a>
-                <CSVLink className="btn btn-sm btn-outline-primary" data={totals.map(toCsvRow)}>
+                <CSVLink className="btn btn-sm btn-outline-primary" data={csvRows.map(toCsvRow)}>
                     Download CSV
                 </CSVLink>
             </div>

--- a/src/components/TransactionsView.tsx
+++ b/src/components/TransactionsView.tsx
@@ -1,0 +1,43 @@
+import { Table } from 'react-bootstrap';
+import CopyButton from './CopyButton';
+import { GAIN_FIELD, type GainsType } from '../utils/GainsCalculator';
+import { formatCurrency, gainClass } from '../utils/format';
+
+interface TransactionsViewProps {
+    rows: GainsType[];
+    isCopied: (i: number) => boolean;
+    onCopy: (i: number) => void;
+}
+
+const TransactionsView = ({ rows, isCopied, onCopy }: TransactionsViewProps) => (
+    <Table responsive hover size="sm" className="cra-table mb-0">
+        <thead>
+            <tr>
+                <th>Transaction</th>
+                <th className="text-end">Proceeds of disposition</th>
+                <th className="text-end">Adjusted cost base</th>
+                <th className="text-end">Outlays and expenses</th>
+                <th className="text-end">Gain (Loss)</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {rows.map((row, i) => {
+                const gainLoss = row[GAIN_FIELD.GainLoss];
+                const copied = isCopied(i);
+                return (
+                    <tr key={i} className={copied ? 'cra-block-copied' : ''}>
+                        <td>{row[GAIN_FIELD.Description]}</td>
+                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.Proceeds])}</td>
+                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.CostBase])}</td>
+                        <td className="text-end cra-table-value">{formatCurrency(row[GAIN_FIELD.Expenses])}</td>
+                        <td className={`text-end cra-table-value ${gainClass(gainLoss)}`}>{formatCurrency(gainLoss)}</td>
+                        <td className="text-end"><CopyButton copied={copied} onClick={() => onCopy(i)} /></td>
+                    </tr>
+                );
+            })}
+        </tbody>
+    </Table>
+);
+
+export default TransactionsView;

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -85,6 +85,13 @@ body {
     white-space: pre-line;
 }
 
+.cra-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 8px 16px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
 .cra-period-title {
     background: #ecf0f1;
     padding: 8px 16px;
@@ -123,6 +130,28 @@ body {
 .cra-row-highlight .cra-row-label {
     color: #000;
     font-weight: 700;
+}
+
+.cra-block-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 8px 16px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.cra-table-value {
+    font-family: 'Courier New', monospace;
+    font-weight: 500;
+}
+
+.cra-block-copied {
+    opacity: 0.55;
+    background: #f3f4f6;
+}
+
+.cra-table tbody tr.cra-block-copied {
+    opacity: 0.55;
+    background: #f3f4f6;
 }
 
 .gain-positive,


### PR DESCRIPTION
Add a view toggle on the Schedule 3 card. Totals view keeps the existing CRA-formatted block per period. Per-transaction view shows a compact table with one row per sale and the same three CRA fields as columns, styled to match the totals view (monospace numbers, right-aligned).

Each block (totals view) and each row (transactions view) gets a Copy button that writes Description/Period name + Proceeds + ACB + Outlays to the clipboard tab-separated, for one-paste entry into the CRA web form's four fields.

Once copied, the block/row stays visually marked (muted + check icon) so the user can track progress through their transactions. State is in-memory and persists across the view toggle.